### PR TITLE
Changes to Health

### DIFF
--- a/Catpocalypse/Assets/Scenes/Level.unity
+++ b/Catpocalypse/Assets/Scenes/Level.unity
@@ -1927,6 +1927,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b57b291273e92e44f8776966d86f0432, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  spawner: {fileID: 1528691241}
 --- !u!1 &1210443998
 GameObject:
   m_ObjectHideFlags: 0
@@ -2428,6 +2429,7 @@ MonoBehaviour:
   spawnPoint1: {fileID: 597612419}
   normalCat: {fileID: 8801225462822087186, guid: 81bdec16b3dc8ef49b5c310d0ff23050, type: 3}
   startWaveButton: {fileID: 1908564806}
+  healthManager: {fileID: 1172394860}
 --- !u!4 &1528691242
 Transform:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Scripts/Cat/CatSpawner.cs
+++ b/Catpocalypse/Assets/Scripts/Cat/CatSpawner.cs
@@ -11,7 +11,7 @@ public class CatSpawner : MonoBehaviour
 
     [SerializeField] private GameObject normalCat;
     [SerializeField] private Button startWaveButton;
-
+    [SerializeField] private PlayerHealthManager healthManager;
 
     private int waveCount = 0;
     private int catsInWave = 5;
@@ -27,7 +27,7 @@ public class CatSpawner : MonoBehaviour
     void Update()
     {
         GameObject[] cats = GameObject.FindGameObjectsWithTag("Cat");
-        if (cats.Length == 0)
+        if (cats.Length == 0 && healthManager.GetPlayerOutOfHealth() != true)
         {
             startWaveButton.enabled = true;
         }                
@@ -43,8 +43,13 @@ public class CatSpawner : MonoBehaviour
         {
             catsInWave += 2;
             StartCoroutine(Spawner());
+            HUD.UpdateWaveNumberDisplay(waveCount);
         }
         startWaveButton.enabled = false;
+    }
+    public void StopSpawner()
+    {
+        StopCoroutine(Spawner());
     }
     IEnumerator Spawner()
     {

--- a/Catpocalypse/Assets/Scripts/PlayerHealthManager.cs
+++ b/Catpocalypse/Assets/Scripts/PlayerHealthManager.cs
@@ -6,10 +6,26 @@ public class PlayerHealthManager : MonoBehaviour
 {
     private float maxHealth = 10f;
     private float health = 10f;
+    [SerializeField] private CatSpawner spawner;
+    private bool playerOutOfHealth = false;
     
     private void Start()
     {
+        
         HUD.UpdatePlayerHealthDisplay(health, maxHealth);
+    }
+    private void Update()
+    {
+        if(health <= 0 && playerOutOfHealth == false)
+        {
+            spawner.StopSpawner();
+            GameObject[] cats = GameObject.FindGameObjectsWithTag("Cat");
+            foreach (GameObject cat in cats)
+            {
+                Destroy(cat);
+            }
+            playerOutOfHealth = true;
+        }
     }
     private void OnTriggerEnter(Collider other)
     {
@@ -19,5 +35,9 @@ public class PlayerHealthManager : MonoBehaviour
             HUD.UpdatePlayerHealthDisplay(health,maxHealth);
             
         }
+    }
+    public bool GetPlayerOutOfHealth()
+    {
+        return playerOutOfHealth;
     }
 }


### PR DESCRIPTION
The player running out of health removes all cats and stops the spawner. It also stops the next wave button from activating. I also added a line of code that updates the Wave number on the HUD.