### PR TITLE
Made camera changes

### DIFF
--- a/Catpocalypse/Assets/Materials/Cats/CatSpawner.prefab
+++ b/Catpocalypse/Assets/Materials/Cats/CatSpawner.prefab
@@ -1,0 +1,186 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &189796813664371473
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5914463992829359606}
+  - component: {fileID: 3777019850466608414}
+  - component: {fileID: 4188931463602211077}
+  - component: {fileID: 2790291121320060503}
+  - component: {fileID: 1603167667455728886}
+  m_Layer: 0
+  m_Name: CatSpawnPoint 1
+  m_TagString: CatSpawnPoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5914463992829359606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189796813664371473}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2541293106647718211}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3777019850466608414
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189796813664371473}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4188931463602211077
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189796813664371473}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2790291121320060503
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189796813664371473}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &1603167667455728886
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 189796813664371473}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1 &216021791644137891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2541293106647718211}
+  - component: {fileID: 2281345131053859659}
+  m_Layer: 0
+  m_Name: CatSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2541293106647718211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 216021791644137891}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5914463992829359606}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2281345131053859659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 216021791644137891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ff1850133f72ce4392fb1774ddc064a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spawnPoint1: {fileID: 5914463992829359606}
+  _CatsInFirstWave: 5
+  normalCat: {fileID: 8801225462822087186, guid: 81bdec16b3dc8ef49b5c310d0ff23050, type: 3}
+  heavyCat: {fileID: 8801225462822087186, guid: ed8838a352deda94682085518b227f89, type: 3}
+  lightCat: {fileID: 2874771900686890139, guid: 9929934472c5eed4f8dfc964b60de407, type: 3}
+  cutenessManager: {fileID: 0}

--- a/Catpocalypse/Assets/Materials/Cats/CatSpawner.prefab.meta
+++ b/Catpocalypse/Assets/Materials/Cats/CatSpawner.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6c70a668de344bd4a943e8a455565a8f
+guid: 52910a1db5af048429c92e28f9a9d141
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Catpocalypse/Assets/Materials/Towers/TowerBaseSelected.mat
+++ b/Catpocalypse/Assets/Materials/Towers/TowerBaseSelected.mat
@@ -78,6 +78,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 0.98963386, b: 0.3443396, a: 1}
+    - _Color: {r: 0, g: 0, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Catpocalypse/Assets/Prefabs/Cats/Chonky cat Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/Chonky cat Variant.prefab
@@ -257,6 +257,8 @@ MonoBehaviour:
   damageToPlayer: 3
   _WayPointArrivedDistance: 2
   distractReward: 50
+  _DistractednessMeterHeightAboveCat: 8
+  _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
 --- !u!64 &7767156934386349427
 MeshCollider:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/Cats/LightCat.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/LightCat.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &2874771900686890139
+--- !u!1 &47135786943904743
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,50 +8,172 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8863361109760334880}
-  - component: {fileID: 4055388850538506174}
-  - component: {fileID: 1067517959594665421}
-  - component: {fileID: 4649053365294732482}
-  - component: {fileID: 5655231517036552516}
-  - component: {fileID: 7167280238853757265}
-  - component: {fileID: 2960915238540690907}
-  m_Layer: 3
+  - component: {fileID: 1191645764713080479}
+  - component: {fileID: 6407903818503566459}
+  - component: {fileID: 8857898166168172032}
+  - component: {fileID: 2372128242861978288}
+  - component: {fileID: 6499068675739851672}
+  m_Layer: 0
   m_Name: LightCat
-  m_TagString: Cat
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8863361109760334880
+--- !u!4 &1191645764713080479
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
+  m_GameObject: {fileID: 47135786943904743}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1246592441044787834}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4055388850538506174
+--- !u!195 &6407903818503566459
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47135786943904743}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 6.45
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 1
+  m_BaseOffset: 0.5
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4
+--- !u!114 &8857898166168172032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47135786943904743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4c67e2e44904c844ae02d2d96ba59e0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _CutenessValue: 1
+  distractionThreshold: 500
+  damageToPlayer: 1
+  _WayPointArrivedDistance: 6
+  distractReward: 25
+  _DistractednessMeterHeightAboveCat: 8
+  _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
+--- !u!64 &2372128242861978288
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47135786943904743}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 8
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 2959467708922500008, guid: d7dc187c064e6c7489ad1f4b4c6d6e91, type: 3}
+--- !u!54 &6499068675739851672
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47135786943904743}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!1 &4888401720962989838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1246592441044787834}
+  - component: {fileID: 4272204768874505659}
+  - component: {fileID: 5585533952566795733}
+  m_Layer: 3
+  m_Name: Sphere
+  m_TagString: Cat
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1246592441044787834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4888401720962989838}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 1191645764713080479}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4272204768874505659
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
+  m_GameObject: {fileID: 4888401720962989838}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &1067517959594665421
+--- !u!23 &5585533952566795733
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
+  m_GameObject: {fileID: 4888401720962989838}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -87,90 +209,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &4649053365294732482
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &5655231517036552516
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!195 &7167280238853757265
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 6.45
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 1
-  m_BaseOffset: 0.5
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
---- !u!114 &2960915238540690907
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2874771900686890139}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a4c67e2e44904c844ae02d2d96ba59e0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _CutenessValue: 1
-  distractionThreshold: 500
-  damageToPlayer: 1
-  _WayPointArrivedDistance: 2
-  distractReward: 25

--- a/Catpocalypse/Assets/Prefabs/Cats/NormalCat.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/NormalCat.prefab
@@ -278,8 +278,10 @@ MonoBehaviour:
   _CutenessValue: 5
   distractionThreshold: 750
   damageToPlayer: 2
-  _WayPointArrivedDistance: 2
+  _WayPointArrivedDistance: 4
   distractReward: 35
+  _DistractednessMeterHeightAboveCat: 8
+  _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
 --- !u!64 &5254691421844368040
 MeshCollider:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/UI/CatDistractednessMeter.prefab
+++ b/Catpocalypse/Assets/Prefabs/UI/CatDistractednessMeter.prefab
@@ -1,0 +1,470 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1241541009678126911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8868012915090559044}
+  - component: {fileID: 2114839661127178220}
+  - component: {fileID: 409042403567396338}
+  m_Layer: 5
+  m_Name: DistractednessLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8868012915090559044
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1241541009678126911}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1024348183500719136}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &2114839661127178220
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1241541009678126911}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &409042403567396338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1241541009678126911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Distractedness:  0 of 0'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 45
+  m_fontSizeBase: 45
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 2114839661127178220}
+  m_maskType: 0
+--- !u!1 &3512654570813597946
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1024348183500719136}
+  - component: {fileID: 5442755865323361497}
+  - component: {fileID: 6910197664162541739}
+  m_Layer: 5
+  m_Name: CatDistractednessMeter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1024348183500719136
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3512654570813597946}
+  m_LocalRotation: {x: 0.38268343, y: 0, z: 0, w: 0.92387956}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.024999999, y: 0.024999999, z: 0.024999999}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 4979874203796137055}
+  - {fileID: 5286029582339464429}
+  - {fileID: 8868012915090559044}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: 75, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &5442755865323361497
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3512654570813597946}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6910197664162541739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3512654570813597946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32b1d2250a66d74aa1abbfdfaa61fe8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4878374360213047742
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5286029582339464429}
+  - component: {fileID: 7697617414981659120}
+  - component: {fileID: 5590150406051118311}
+  - component: {fileID: 1629861895997512830}
+  - component: {fileID: 1785417548082242032}
+  m_Layer: 5
+  m_Name: DistractednessBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5286029582339464429
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878374360213047742}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 1024348183500719136}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -2, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7697617414981659120
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878374360213047742}
+  m_CullTransparentMesh: 1
+--- !u!114 &5590150406051118311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878374360213047742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.5, b: 0.011688352, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 9875f636ba4251a47a5f85feb8ad8457, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 0.161
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!223 &1629861895997512830
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878374360213047742}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 1
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: -1
+  m_TargetDisplay: 0
+--- !u!114 &1785417548082242032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4878374360213047742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!1 &8644024770491736238
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4979874203796137055}
+  - component: {fileID: 5386440706521279641}
+  - component: {fileID: 8893460251266385258}
+  - component: {fileID: 7802335689424273219}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4979874203796137055
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8644024770491736238}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1024348183500719136}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5386440706521279641
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8644024770491736238}
+  m_CullTransparentMesh: 1
+--- !u!114 &8893460251266385258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8644024770491736238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!223 &7802335689424273219
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8644024770491736238}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 1
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: -2
+  m_TargetDisplay: 0

--- a/Catpocalypse/Assets/Prefabs/UI/CatDistractednessMeter.prefab.meta
+++ b/Catpocalypse/Assets/Prefabs/UI/CatDistractednessMeter.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6c70a668de344bd4a943e8a455565a8f
+guid: e633f4d5486c0f542b4af3b4ecb326ae
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Catpocalypse/Assets/Scenes/Level.unity
+++ b/Catpocalypse/Assets/Scenes/Level.unity
@@ -4988,11 +4988,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 085ee927fee6f59469b77849b72897fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _CameraMouseDragMoveSpeed: 8
   _CameraMoveSpeed: 12
-  _DragMovementButton: 2
   _CameraTargetObject: {fileID: 1222495213}
   _CameraMoveLimits: {x: 20, y: 20, z: 20}
-  _MinZoomDistance: 8
+  _DragMovementButton: 2
+  _InvertMouseInputForDrags: 1
+  _CameraStartTarget: {fileID: 0}
+  _MinZoomDistance: 4
   _MaxZoomeDistance: 64
   _ZoomRate: 2
   _InvertScrollwheelInput: 1
@@ -5812,7 +5815,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 208426c70451e414c938e16f1d7aa683, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  startWaveButton: {fileID: 1908564806}
+  _TotalWavesInLevel: 5
 --- !u!4 &1241258564
 Transform:
   m_ObjectHideFlags: 0
@@ -6794,10 +6797,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spawnPoint1: {fileID: 597612419}
+  _CatsInFirstWave: 5
   normalCat: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
   heavyCat: {fileID: 5758637314826502625, guid: b44e41471936f3248b4cdd4778258f38, type: 3}
-  lightCat: {fileID: 2874771900686890139, guid: 9929934472c5eed4f8dfc964b60de407, type: 3}
-  healthManager: {fileID: 1172394860}
+  lightCat: {fileID: 47135786943904743, guid: 6c70a668de344bd4a943e8a455565a8f, type: 3}
   cutenessManager: {fileID: 1172394861}
 --- !u!4 &1528691242
 Transform:

--- a/Catpocalypse/Assets/Scenes/Level1.unity
+++ b/Catpocalypse/Assets/Scenes/Level1.unity
@@ -5860,12 +5860,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 085ee927fee6f59469b77849b72897fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _CameraMouseDragMoveSpeed: 8
   _CameraMoveSpeed: 12
   _CameraTargetObject: {fileID: 23430531}
   _CameraMoveLimits: {x: 100, y: 100, z: 100}
   _DragMovementButton: 2
   _InvertMouseInputForDrags: 1
-  _MinZoomDistance: 8
+  _CameraStartTarget: {fileID: 1428254386}
+  _MinZoomDistance: 4
   _MaxZoomeDistance: 64
   _ZoomRate: 2
   _InvertScrollwheelInput: 1
@@ -8304,139 +8306,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
   m_PrefabInstance: {fileID: 712877347}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &727217802
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 727217803}
-  - component: {fileID: 727217807}
-  - component: {fileID: 727217806}
-  - component: {fileID: 727217805}
-  - component: {fileID: 727217804}
-  m_Layer: 0
-  m_Name: CatSpawnPoint 1
-  m_TagString: CatSpawnPoint
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &727217803
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 727217802}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 14.99, y: 1, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 852345655}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!54 &727217804
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 727217802}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!65 &727217805
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 727217802}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &727217806
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 727217802}
-  m_Enabled: 0
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &727217807
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 727217802}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &766145013
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8535,7 +8404,7 @@ Transform:
   m_GameObject: {fileID: 773447302}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 14.99, y: 1, z: 0}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -9840,57 +9709,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
   m_PrefabInstance: {fileID: 850665754}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &852345653
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 852345655}
-  - component: {fileID: 852345654}
-  m_Layer: 0
-  m_Name: CatSpawner
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &852345654
+--- !u!114 &852345654 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2281345131053859659, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+  m_PrefabInstance: {fileID: 3207847555835823690}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 852345653}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4ff1850133f72ce4392fb1774ddc064a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  spawnPoint1: {fileID: 727217803}
-  _CatsInFirstWave: 5
-  normalCat: {fileID: 8801225462822087186, guid: 81bdec16b3dc8ef49b5c310d0ff23050, type: 3}
-  heavyCat: {fileID: 8801225462822087186, guid: ed8838a352deda94682085518b227f89, type: 3}
-  lightCat: {fileID: 2874771900686890139, guid: 9929934472c5eed4f8dfc964b60de407, type: 3}
-  cutenessManager: {fileID: 439936121}
---- !u!4 &852345655
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 852345653}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 60.27787, y: 0, z: 8.101217}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 727217803}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &873083549 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3555554166829222618, guid: 21db29107db5be3428569a8365b5f48a, type: 3}
@@ -11461,7 +11290,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_BindingMode: 1
-  m_FollowOffset: {x: 0, y: 20, z: -10}
+  m_FollowOffset: {x: 0, y: 25, z: -15}
   m_XDamping: 0
   m_YDamping: 0
   m_ZDamping: 0
@@ -14003,8 +13832,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 647, y: 364}
-  m_SizeDelta: {x: 1919.9999, y: 1080.1854}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1411493062
 MonoBehaviour:
@@ -14194,6 +14023,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 21db29107db5be3428569a8365b5f48a, type: 3}
+--- !u!1 &1428254386 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 99213144838246505, guid: eb060bb96e8b3af44919fdea4c2b05b7, type: 3}
+  m_PrefabInstance: {fileID: 814406171}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1430067529
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15977,6 +15811,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 208426c70451e414c938e16f1d7aa683, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _TotalWavesInLevel: 5
 --- !u!4 &1626300300
 Transform:
   m_ObjectHideFlags: 0
@@ -19130,9 +18965,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   spawnPoint1: {fileID: 773447303}
   _CatsInFirstWave: 5
-  normalCat: {fileID: 8801225462822087186, guid: 81bdec16b3dc8ef49b5c310d0ff23050, type: 3}
-  heavyCat: {fileID: 8801225462822087186, guid: ed8838a352deda94682085518b227f89, type: 3}
-  lightCat: {fileID: 2874771900686890139, guid: 9929934472c5eed4f8dfc964b60de407, type: 3}
+  normalCat: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+  heavyCat: {fileID: 5758637314826502625, guid: b44e41471936f3248b4cdd4778258f38, type: 3}
+  lightCat: {fileID: 47135786943904743, guid: 6c70a668de344bd4a943e8a455565a8f, type: 3}
   cutenessManager: {fileID: 439936121}
 --- !u!4 &1993721025
 Transform:
@@ -19143,7 +18978,7 @@ Transform:
   m_GameObject: {fileID: 1993721023}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 60.27787, y: 0, z: -7.63}
+  m_LocalPosition: {x: 75, y: 0, z: -7.63}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -21196,8 +21031,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 647, y: 364}
-  m_SizeDelta: {x: 1919.9999, y: 1080.1854}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2123925136
 MonoBehaviour:
@@ -21447,20 +21282,93 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a58c6e6c38e3cb74494eeccf680427a9, type: 3}
+--- !u!1001 &3207847555835823690
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 216021791644137891, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_Name
+      value: CatSpawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 2281345131053859659, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: heavyCat
+      value: 
+      objectReference: {fileID: 5758637314826502625, guid: b44e41471936f3248b4cdd4778258f38, type: 3}
+    - target: {fileID: 2281345131053859659, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: lightCat
+      value: 
+      objectReference: {fileID: 47135786943904743, guid: 6c70a668de344bd4a943e8a455565a8f, type: 3}
+    - target: {fileID: 2281345131053859659, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: normalCat
+      value: 
+      objectReference: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+    - target: {fileID: 2281345131053859659, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: cutenessManager
+      value: 
+      objectReference: {fileID: 439936121}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 8.101217
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2541293106647718211, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 52910a1db5af048429c92e28f9a9d141, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1227290386}
+  - {fileID: 23430531}
   - {fileID: 2111749096}
   - {fileID: 555886982}
-  - {fileID: 852345655}
+  - {fileID: 3207847555835823690}
   - {fileID: 1993721025}
   - {fileID: 875652316}
   - {fileID: 78743776}
   - {fileID: 439936120}
   - {fileID: 1952865348}
-  - {fileID: 23430531}
   - {fileID: 1656324948}
   - {fileID: 947851305435217356}
   - {fileID: 574731849}

--- a/Catpocalypse/Assets/Scripts/Camera/CameraController.cs
+++ b/Catpocalypse/Assets/Scripts/Camera/CameraController.cs
@@ -14,8 +14,11 @@ public class CameraController : MonoBehaviour
 
 
     [Header("Camera Movement Settings")]
-    [Tooltip("The movement speed of the camera in meters per second.")]
-    [SerializeField] private float _CameraMoveSpeed = 5f;
+    [Tooltip("The movement speed of the camera when you click and drag.")]
+    [SerializeField] private float _CameraMouseDragMoveSpeed = 8f;
+
+    [Tooltip("The movement speed of the camera in meters per second when you pan using WASD, arrowkeys, or left stick on a gamepad.")]
+    [SerializeField] private float _CameraMoveSpeed = 10f;
 
     // See the comments in the InitCamera() function below for more on this object.
     [SerializeField] private Transform _CameraTargetObject;
@@ -29,10 +32,13 @@ public class CameraController : MonoBehaviour
     [Tooltip("This property specifies whether or not the mouse move amount is inverted before being used to move the camera.")]
     [SerializeField] private bool _InvertMouseInputForDrags = true;
 
+    [Tooltip("This specifies the object the camera will be focused on at the start of the level. If it is null, then it will start focused on (0,0,0).")]
+    [SerializeField] private GameObject _CameraStartTarget;
+
 
     [Header("Zoom Settings")]
     [Tooltip("The minimum zoom distance (in units/meters).")]
-    [SerializeField] private float _MinZoomDistance = 8f;
+    [SerializeField] private float _MinZoomDistance = 4f;
     [Tooltip("The maximum zoom distance (in units/meters).")]
     [SerializeField] private float _MaxZoomeDistance = 64f;
     [Tooltip("How much (in units/meters) that the camera moves forward/back per mouse scroll wheel movement.")]
@@ -52,6 +58,10 @@ public class CameraController : MonoBehaviour
         _CameraTargetObject.gameObject.SetActive(true);
         _VirtualCamera = GetComponent<CinemachineVirtualCamera>();
 
+        if (_CameraStartTarget != null)
+            _CameraTargetObject.transform.position = _CameraStartTarget.transform.position;
+
+
         InitCamera();
     }
 
@@ -69,7 +79,7 @@ public class CameraController : MonoBehaviour
             AdjustZoomLevel(Mouse.current.scroll.value);
 
         if (PlayerInputManager.PanCamera != Vector2.zero)
-            MoveCamera(PlayerInputManager.PanCamera);
+            MoveCamera(PlayerInputManager.PanCamera * _CameraMoveSpeed);
 
         HandleMouseDrags();
     }
@@ -84,7 +94,7 @@ public class CameraController : MonoBehaviour
             // Get the mouse move amount.
             Vector2 delta = Mouse.current.delta.value;
 
-            MoveCamera(_InvertMouseInputForDrags ? -delta : delta);
+            MoveCamera((_InvertMouseInputForDrags ? -delta : delta) * _CameraMouseDragMoveSpeed);
         }
     }
 
@@ -92,7 +102,7 @@ public class CameraController : MonoBehaviour
     {
         // Calculate the move distance on both the X and Z axis. We just set Y to 0 so the camera
         // stays at the height it is at.
-        Vector3 moveDistance = new Vector3(moveInput.x * _CameraMoveSpeed, 0f, moveInput.y * _CameraMoveSpeed);
+        Vector3 moveDistance = new Vector3(moveInput.x, 0f, moveInput.y);
 
         // We also multiply by Time.deltaTime so that the camera will move the correct amount
         // regardless of the current frame rate.
@@ -159,4 +169,5 @@ public class CameraController : MonoBehaviour
         _VirtualCamera.GetCinemachineComponent<CinemachineTransposer>().m_FollowOffset *= scale;
     }
 
+   
 }

--- a/Catpocalypse/Assets/Scripts/Cat/CatBase.cs
+++ b/Catpocalypse/Assets/Scripts/Cat/CatBase.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 
 using UnityEngine;
 using UnityEngine.AI;
+using UnityEngine.UI;
+using TMPro;
 
 // This fixes the ambiguity between System.Random and UnityEngine.Random by
 // telling it to use the Unity one.
@@ -12,6 +14,10 @@ using Random = UnityEngine.Random;
 
 public class CatBase : MonoBehaviour
 {
+    public static bool ShowDistractednessBar = true;
+
+
+
     // This event is static so we don't need to subscribe the money manager to every cat instance's OnCatDied event.
     public static event EventHandler OnCatDied;
 
@@ -31,6 +37,12 @@ public class CatBase : MonoBehaviour
 
     [SerializeField] protected int distractReward = 50;
 
+    [Header("Distractedness Meter")]
+    [SerializeField] protected float _DistractednessMeterHeightAboveCat = 2f;
+    [SerializeField] protected GameObject _DistractednessMeterPrefab;
+
+
+
     protected int distraction = 0; //How distracted the cat is currently
     protected bool isDistracted = false; // If the cat has been defeated or not.
     //Rigidbody rb;//The RigidBody component
@@ -41,9 +53,16 @@ public class CatBase : MonoBehaviour
     protected float _DistanceFromNextWayPoint = 0f;
     protected WayPoint _NextWayPoint;
 
+    protected GameObject _DistractednessMeterGO;
+    protected Image _DistractednessMeterBarImage;
+    protected TextMeshPro _DistractednessMeterLabel;
+
+
     // Start is called before the first frame update
     void Start()
     {
+        InitDistractednessMeter();
+
         agent = GetComponent<NavMeshAgent>();
         healthManager = GameObject.FindGameObjectWithTag("Goal").gameObject.GetComponent<PlayerHealthManager>();
 
@@ -78,7 +97,31 @@ public class CatBase : MonoBehaviour
         {
             _DistanceFromNextWayPoint = 0f;
         }
+
+
+        _DistractednessMeterGO.SetActive(ShowDistractednessBar);
     }
+
+    private void InitDistractednessMeter()
+    {
+        Transform distractednessMeter = Instantiate(_DistractednessMeterPrefab).transform;
+        _DistractednessMeterGO = distractednessMeter.gameObject;
+
+        distractednessMeter.SetParent(transform, true); // I'm parenting it this way rather than using the Instantiate() function above, because I need it to not inherit scale from the cat.
+        distractednessMeter.localPosition = new Vector3(0, _DistractednessMeterHeightAboveCat, 0);
+
+        _DistractednessMeterBarImage = distractednessMeter.Find("DistractednessBar").GetComponent<Image>();
+        _DistractednessMeterLabel = distractednessMeter.Find("DistractednessLabel").GetComponent<TextMeshPro>();
+
+        UpdateDistractednessMeter();
+    }
+
+    private void UpdateDistractednessMeter()
+    {        
+        _DistractednessMeterBarImage.fillAmount = (float) distraction / distractionThreshold;
+        _DistractednessMeterLabel.text = $"Distractedness: {distraction} of {distractionThreshold}";
+    }
+
     protected void Distracted()
     {
         isDistracted = true;
@@ -87,9 +130,11 @@ public class CatBase : MonoBehaviour
     public void DistractCat(int distractionValue, Tower targetingTower)
     {
         distraction += distractionValue;
+        UpdateDistractednessMeter();
+
         if (this.distraction >= this.distractionThreshold)
         {
-            targetingTower.targets.Remove(this.gameObject);
+            targetingTower.targets.Remove(this.gameObject);           
             KillCat();
         }
     }
@@ -109,6 +154,11 @@ public class CatBase : MonoBehaviour
         // Fire the OnCatDied event.
         OnCatDied?.Invoke(this, EventArgs.Empty);
 
+        // Destroy the cat's distractedness meter.
+        // NOTE: You have to get the gameObject. I ended at parent originally, and it gave me a wierd error that it couldn't remove RectTransform when it tried to destroy the meter.
+        Destroy(_DistractednessMeterBarImage.transform.parent.gameObject);
+
+        // Destroy the cat.
         Destroy(gameObject);
     }
 

--- a/Catpocalypse/Assets/Scripts/FaceCamera.cs
+++ b/Catpocalypse/Assets/Scripts/FaceCamera.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+/// <summary>
+/// Add this component to a GameObject to make it always face the camera.
+/// </summary>
+public class FaceCamera : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        transform.LookAt(Camera.main.transform);
+    }
+}

--- a/Catpocalypse/Assets/Scripts/FaceCamera.cs.meta
+++ b/Catpocalypse/Assets/Scripts/FaceCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9c3e9e2d2765f045b802cedfdca326d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/FollowParentWithoutRotating.cs
+++ b/Catpocalypse/Assets/Scripts/FollowParentWithoutRotating.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FollowParentWithoutRotating : MonoBehaviour
+{
+    Quaternion _StartingRotation;
+
+
+
+    private void Awake()
+    {
+        // Save the current rotation.
+        _StartingRotation = transform.rotation;    
+    }
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        // Force the object to not rotate when the parent does.
+        transform.rotation = _StartingRotation;
+    }
+}

--- a/Catpocalypse/Assets/Scripts/FollowParentWithoutRotating.cs.meta
+++ b/Catpocalypse/Assets/Scripts/FollowParentWithoutRotating.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b32b1d2250a66d74aa1abbfdfaa61fe8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/UI/HUD.cs
+++ b/Catpocalypse/Assets/Scripts/UI/HUD.cs
@@ -84,6 +84,10 @@ public class HUD : MonoBehaviour
 
     public static void HideWaveDisplay()
     {
+        if (_Instance == null)
+            return;
+
+
         _Instance.WaveNumberLabel.gameObject.SetActive(false);
         _Instance.CatsRemainingLabel.gameObject.SetActive(false);
         
@@ -93,6 +97,10 @@ public class HUD : MonoBehaviour
 
     public static void ShowWaveDisplay()
     {
+        if (_Instance == null)
+            return;
+
+
         // Clear the text labels, so the player won't potentially see an old value before it updates.
         _Instance.WaveNumberLabel.text = "";
         _Instance.CatsRemainingLabel.text = "";

--- a/Catpocalypse/UserSettings/EditorUserSettings.asset
+++ b/Catpocalypse/UserSettings/EditorUserSettings.asset
@@ -12,10 +12,10 @@ EditorUserSettings:
       value: 0609005552570d08080f097516720744124f4c282e7124647a2c1f37b6e1366b
       flags: 0
     RecentlyUsedSceneGuid-2:
-      value: 500957045d56085d55565c2713720c444e4f417a7d2b72347f2f4860b2e3313a
+      value: 5a08505f54500c5f5f0a0f7713745a44414e48792a2b24697b7a1e66bae2663c
       flags: 0
     RecentlyUsedSceneGuid-3:
-      value: 5a08505f54500c5f5f0a0f7713745a44414e48792a2b24697b7a1e66bae2663c
+      value: 500957045d56085d55565c2713720c444e4f417a7d2b72347f2f4860b2e3313a
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
I added a new setting on the CameraController that lets you set an object that it will be focused on when the level starts. That way we can easily control where the camera looks when a level begins. It starts at the starting area on Level1 now.

I added bars above the cats to show how distracted they are. CatBase has a static bool that controls whether or not they are displayed. That way it can easily be optional for players later if we want.

I also changed the tower base select color to dark blue.