### PR TITLE
Fixed towerbases are clickable and hoverable while mouse is over a UI…

### DIFF
--- a/Catpocalypse/Assets/Scenes/Level1.unity
+++ b/Catpocalypse/Assets/Scenes/Level1.unity
@@ -15928,7 +15928,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4509841520001507126, guid: 83fd67a81a6a9fd468f9f74c0f3ccbe6, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -0.0004272461
+      value: -0.00048828125
       objectReference: {fileID: 0}
     - target: {fileID: 4509841520001507126, guid: 83fd67a81a6a9fd468f9f74c0f3ccbe6, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -15961,6 +15961,10 @@ PrefabInstance:
     - target: {fileID: 4532627647641803434, guid: 83fd67a81a6a9fd468f9f74c0f3ccbe6, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4770068560748751643, guid: 83fd67a81a6a9fd468f9f74c0f3ccbe6, type: 3}
+      propertyPath: m_CullTransparentMesh
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4992015069156196963, guid: 83fd67a81a6a9fd468f9f74c0f3ccbe6, type: 3}
       propertyPath: m_Type

--- a/Catpocalypse/Assets/Scripts/Towers/TowerBase.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/TowerBase.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 
@@ -47,7 +48,12 @@ public class TowerBase : MonoBehaviour
 
     void OnMouseEnter()
     {
-       hoveredOver = true;
+        // Check if the mouse is over a UI element. If so, then we should ignore the click.
+        if (EventSystem.current.IsPointerOverGameObject())
+            return;
+
+
+        hoveredOver = true;
 
         // Don't set the hover color if the tower is selected.
         if (!IsSelected)
@@ -56,6 +62,13 @@ public class TowerBase : MonoBehaviour
 
     void OnMouseExit()
     {
+        // NOTE: I did not add the EventSystem check here like I did in OnMouseEnter() and OnMouseUpAsButton().
+        //       This is because we don't need it here. If we put it here, it will cause the issue that you 
+        //       could move the mouse off of the tower base, and it will then stay highlighted errouneously
+        //       if the mouse stays on a UI element while moving off of the tower base.
+
+
+
         hoveredOver = false;
         
         // Don't restore normal material unless the tower is not selected.
@@ -65,6 +78,11 @@ public class TowerBase : MonoBehaviour
 
     void OnMouseUpAsButton()
     {
+        // Check if the mouse is over a UI element. If so, then we should ignore the click.
+        if (EventSystem.current.IsPointerOverGameObject())
+            return;
+
+
         gameObject.GetComponent<Renderer>().material = towerSelected;
         IsSelected = true;
         


### PR DESCRIPTION
… element.

Found the fix with a little help from Google. It's just a simple if statement added at the top of OnMouseEnter() and OnMouseUpAsButton() in TowerBase.cs:

```c#
        // Check if the mouse is over a UI element. If so, then we should ignore the click.
        if (EventSystem.current.IsPointerOverGameObject())
            return;
``` 

This code just asks the EventSystem if the mouse is over an EventSystem object (UI element).