### PR TITLE
Implemented a state machine for towers and cats

### DIFF
--- a/Catpocalypse/Assets/Scenes/Level.unity
+++ b/Catpocalypse/Assets/Scenes/Level.unity
@@ -1098,6 +1098,65 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 173338882}
   m_CullTransparentMesh: 1
+--- !u!1 &243126152
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 243126154}
+  - component: {fileID: 243126153}
+  - component: {fileID: 243126155}
+  m_Layer: 0
+  m_Name: StateMachineTester
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &243126153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 243126152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0194ef5f47023f9418997e7c1476670e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Value: 0
+--- !u!4 &243126154
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 243126152}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 31.85051, y: -3135.8132, z: 2642.2969}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &243126155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 243126152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a381c3779cca78419bf814c3b35c05e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  AllowUnknownStates: 0
 --- !u!1 &259030402
 GameObject:
   m_ObjectHideFlags: 0
@@ -2997,6 +3056,140 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &671499477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 671499478}
+  - component: {fileID: 671499480}
+  - component: {fileID: 671499479}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &671499478
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671499477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1002087101}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &671499479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671499477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Non-Allergic
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 3.622612, y: 0, z: 2.947281, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &671499480
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671499477}
+  m_CullTransparentMesh: 1
 --- !u!1 &678951878
 GameObject:
   m_ObjectHideFlags: 0
@@ -4725,6 +4918,153 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fdd664e1dfed8c74a81d92e310a79b44, type: 3}
+--- !u!1 &1002087096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1002087101}
+  - component: {fileID: 1002087100}
+  - component: {fileID: 1002087098}
+  - component: {fileID: 1002087097}
+  - component: {fileID: 1002087099}
+  m_Layer: 5
+  m_Name: NonAllergicTowerBtn (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1002087097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002087096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1002087098}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: TowerSelectorUI, Assembly-CSharp
+        m_MethodName: OnNATowerSelect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1002087098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002087096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1002087099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002087096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 977f146db981a58469cf295f191849d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TowerType: 5
+--- !u!222 &1002087100
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002087096}
+  m_CullTransparentMesh: 1
+--- !u!224 &1002087101
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002087096}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 671499478}
+  m_Father: {fileID: 1409067347}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 10.21875}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1019788627
 GameObject:
   m_ObjectHideFlags: 0
@@ -7208,6 +7548,7 @@ RectTransform:
   - {fileID: 1085426213}
   - {fileID: 527890157}
   - {fileID: 89379572}
+  - {fileID: 1002087101}
   - {fileID: 991998823}
   m_Father: {fileID: 170588548}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -7273,6 +7614,7 @@ MonoBehaviour:
   cucumberThrowerTowerBtn: {fileID: 1085426210}
   stringWaverTowerBtn: {fileID: 527890158}
   yarnBallTowerBtn: {fileID: 89379573}
+  nonAllergicTowerBtn: {fileID: 1002087097}
   closeBtn: {fileID: 991998824}
   notEnoughFundsScreen: {fileID: 1388924961}
   playerMoneyManager: {fileID: 1172394862}
@@ -7321,6 +7663,7 @@ MonoBehaviour:
   cucumberTowerPrefab: {fileID: 6448288126085725347, guid: bab15dc771dc3464a85b4283f9710e6f, type: 3}
   stringWaverTowerPrefab: {fileID: 8043389372904318211, guid: 26fc2ecdaca6a2d48b8d900808be3691, type: 3}
   yarnBallTowerPrefab: {fileID: 6053846418755319415, guid: b24ec43d900efa548b8861aaed8dc24a, type: 3}
+  naTowerPrefab: {fileID: 1494292692984174254, guid: 3cc1d5d3792ea7a4eb862e4db2506356, type: 3}
 --- !u!1 &1413049960
 GameObject:
   m_ObjectHideFlags: 0
@@ -7635,7 +7978,7 @@ MonoBehaviour:
   _CatsInFirstWave: 5
   normalCat: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
   heavyCat: {fileID: 5758637314826502625, guid: b44e41471936f3248b4cdd4778258f38, type: 3}
-  lightCat: {fileID: 47135786943904743, guid: 6c70a668de344bd4a943e8a455565a8f, type: 3}
+  lightCat: {fileID: 2247931869541265458, guid: 3ca6ad5e0d8d6ce409ff571221648ad3, type: 3}
   cutenessManager: {fileID: 1172394861}
 --- !u!4 &1528691242
 Transform:
@@ -9815,3 +10158,4 @@ SceneRoots:
   - {fileID: 827851488}
   - {fileID: 443925530}
   - {fileID: 1241258564}
+  - {fileID: 243126154}

--- a/Catpocalypse/Assets/Scripts/Cat/CatBase.cs
+++ b/Catpocalypse/Assets/Scripts/Cat/CatBase.cs
@@ -12,6 +12,8 @@ using TMPro;
 using Random = UnityEngine.Random;
 using UnityEngine.UIElements;
 
+
+[RequireComponent(typeof(StateMachine))]
 public class CatBase : MonoBehaviour
 {
     public static bool ShowDistractednessBar = true;
@@ -69,6 +71,9 @@ public class CatBase : MonoBehaviour
     public bool isATarget = false;
     private float speed;
 
+    private StateMachine _stateMachine;
+
+
     // Start is called before the first frame update
     void Start()    
     {
@@ -87,7 +92,16 @@ public class CatBase : MonoBehaviour
         // Find the closest WayPoint and start moving there.
         FindNearestWayPoint();
         agent.SetDestination(_NextWayPoint.transform.position);
-        
+
+
+        if (_stateMachine == null)
+        {
+            _stateMachine = GetComponent<StateMachine>();
+            if (_stateMachine == null)
+                throw new Exception($"The cat \"{gameObject.name}\" does not have a StateMachine component!");
+
+            InitStateMachine();
+        }
     }
 
     // Update is called once per frame
@@ -123,6 +137,31 @@ public class CatBase : MonoBehaviour
 
         _DistractednessMeterGO.SetActive(ShowDistractednessBar);
     }
+
+    /// <summary>
+    /// This function sets up the state machine with a very basic setup that just uses the base class for each state.
+    /// </summary>
+    protected virtual void InitStateMachine()
+    {
+        // Create tower states.
+        CatState_Idle_Base idleState = new CatState_Idle_Base(this);
+
+
+        // Create and register transitions.
+
+
+        // Tell state machine to write in the debug console every time it exits or enters a state.
+        //_stateMachine.EnableDebugLogging = true;
+
+        // This is necessary since we only have one state and no transitions for now.
+        // Mouse over the AllowUnknownStates property for more info.
+        _stateMachine.AllowUnknownStates = true;
+
+
+        // Set the starting state.
+        _stateMachine.SetState(idleState);
+    }
+
     private void InitDistractednessMeter()
     {
         Transform distractednessMeter = Instantiate(_DistractednessMeterPrefab).transform;

--- a/Catpocalypse/Assets/Scripts/StateMachine.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af24f7f6ce8f451498860d027a6e12c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachine/IState.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachine/IState.cs
@@ -1,0 +1,10 @@
+
+public interface IState
+{
+    void OnEnter();
+    void OnUpdate();
+    void OnExit();
+
+
+    string Name { get; }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachine/IState.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachine/IState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a37cf5a725e9124dbe7572081451e8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachine/StateMachine.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachine/StateMachine.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+
+
+/// <summary>
+/// This state machine can be used for anything. You just need to override the State_Base class to make your own states for that thing.
+/// </summary>
+/// <remarks>
+/// NOTE: Any class that uses this state machine should have a [RequireComponent(typeof(StateMachine))] attribute on it so that
+///       the GameObject will automatically get a StateMachine component. Then the class that uses it can just call GetComponent<StateMachine>()
+///       to grab a reference to it.
+/// </remarks>
+public class StateMachine : MonoBehaviour
+{
+    private IState _currentState;
+
+
+    // This list holds all transitions that can happen from any state.
+    private List<Transition> _fromAnyStateTransitions = new List<Transition>();
+
+    // This dictionary holds all transitions that can only happen from a specified state.
+    private Dictionary<string, List<Transition>> _fromStateTransitions = new Dictionary<string, List<Transition>>();
+
+    // This dictionary holds all states that the state machine knows about from the transitions that have been set.
+    private Dictionary<string, IState> _statesByNameLookup = new Dictionary<string, IState>();
+    private Dictionary<Type, IState> _statesByTypeLookup = new Dictionary<Type, IState>();
+
+
+
+    void Awake()
+    {
+        IsEnabled = true;
+    }
+
+    void Start()
+    {
+        
+    }
+
+    void Update()
+    {
+        if (!IsEnabled)
+            return;
+
+
+        bool wasStateChanged = DoTransitionsCheck();
+
+        _currentState?.OnUpdate();           
+    }
+
+    /// <summary>
+    /// This function checks to see if a state machine transition should occur this frame or not.
+    /// </summary>
+    /// <returns>Returns true if a state machine transition was triggered, or false otherwise.</returns>
+    private bool DoTransitionsCheck()
+    {
+        // First check transitions that can only occur in the current state.
+        // If no matches are found, then check all transitions that can occur from any other state.
+        bool transitionTriggered = DoSpecificStateTransitionsCheck();        
+        return transitionTriggered ? transitionTriggered : DoAnyStateTransitionsCheck();
+    }
+
+    /// <summary>
+    /// This function checks all transitions that can only occur in the current state to see if any of them return true.
+    /// </summary>
+    /// <returns>Returns true if a state machine transition was triggered, or false otherwise.</returns>
+    private bool DoSpecificStateTransitionsCheck()
+    {
+        if (!_fromStateTransitions.TryGetValue(CurrentState.Name, out List<Transition> transitions))
+            return false;
+
+        foreach (Transition t in transitions)
+        {
+            // Check that we are not already in this transition's target state, and that
+            // the condition for this transition is true.
+            if (CheckTransitionCondition(t))
+            { 
+                return true;
+            }
+
+        } // end foreach
+
+
+        return false;
+    }
+
+    /// <summary>
+    /// This function checks all transitions that can occur from any other state to see if any of them return true.
+    /// </summary>
+    /// <returns>Returns true if a state machine transition was triggered, or false otherwise.</returns>
+    private bool DoAnyStateTransitionsCheck()
+    {
+        foreach (Transition t in _fromAnyStateTransitions)
+        { 
+            // Check that we are not already in this transition's target state, and that
+            // the condition for this transition is true.
+            if (CheckTransitionCondition(t))
+            {
+                return true;
+            }
+
+        } // end foreach
+
+
+        return false;
+    }
+    
+    /// <summary>
+    /// This function simply calls the CheckTransitionCondition() delegate for the specified
+    /// transition. If it returns true, then it will call ChangeState() to activate the transition.
+    /// </summary>
+    /// <param name="t">The transition whose condition is to be checked.</param>
+    /// <returns>True if it triggered a state machine transition, and false otherwise.</returns>
+    private bool CheckTransitionCondition(Transition t)
+    {
+        // Check that we are not already in this transition's target state, and that
+        // the condition for this transition is true.
+        if (_currentState.Name != t.ToState.Name &&
+            t.CheckTransitionCondition())
+        {
+            return ChangeState(t.ToState);
+        }
+
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sets the state of the state machine. In practice the SetState() methods should be avoided outside of setting the starting state, as it is better to use the transitions to control state changes.
+    /// </summary>
+    /// <param name="state">The state to switch to.</param>
+    /// <returns>True if the state machine has switched states successfully.</returns>
+    public bool SetState(IState state)
+    {
+        if (state == null)
+            throw new Exception("The passed in state is null!");
+
+
+        return ChangeState(state);
+    }
+
+    /// <summary>
+    /// Sets the state of the state machine. In practice the SetState() methods should be avoided outside of setting the starting state, as it is better to use the transitions to control state changes.
+    /// </summary>
+    /// <param name="state">The C# class name of the state to switch to.</param>
+    /// <returns>True if the state machine has switched states successfully.</returns>
+    public bool SetState(string stateClassName)
+    {
+        if (string.IsNullOrWhiteSpace(stateClassName))
+            throw new Exception("The passed in state name string is null or empty!");
+
+
+        _statesByNameLookup.TryGetValue(stateClassName, out IState state);
+        if (state != null)
+        {
+            return ChangeState(state);
+        }
+        else
+        {
+            LogUnknownStateError(stateClassName);
+            return false;
+        }
+
+    }
+
+    /// <summary>
+    /// Sets the state of the state machine. In practice the SetState() methods should be avoided outside of setting the starting state, as it is better to use the transitions to control state changes.
+    /// </summary>
+    /// <param name="state">The C# class type of the state to switch to.</param>
+    /// <returns>True if the state machine has switched states successfully.</returns>
+    public bool SetState(Type stateType)
+    {
+        if (stateType == null)
+            throw new Exception("The passed in state type is null!");
+
+
+        _statesByTypeLookup.TryGetValue(stateType, out IState state);
+        if (state != null)
+        {
+            return ChangeState(state);
+        }
+        else
+        {
+            LogUnknownStateError(stateType.GetType().Name);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Changes the state of the state machine.
+    /// </summary>
+    /// <param name="state">The state to switch to.</param>
+    /// <returns>True if the state machine has switched states successfully.</returns>
+    private bool ChangeState(IState state)
+    {
+        bool isInList = _statesByNameLookup.ContainsKey(state.Name);
+
+
+        // If enabled, then register the state if it is not in the list.
+        if (!isInList && AllowUnknownStates)
+        {
+            AddStateToLookupTables(state);
+            isInList = true;
+        }
+
+
+        // If the passed in state is in the list, then switch to that state.
+        if (isInList)
+        {
+            _currentState?.OnExit();
+
+            if (EnableDebugLogging && _currentState != null)
+                Debug.Log($"Exited state \"{CurrentState.Name}\".");
+
+            _currentState = state;
+            _currentState?.OnEnter();
+
+            if (EnableDebugLogging)
+                Debug.Log($"Entered state \"{state.Name}\".");
+
+            return true;
+        }
+        else
+        {
+            LogUnknownStateError(state.Name);
+            return false;
+        }
+    }
+
+    private void LogUnknownStateError(string stateName)
+    {
+        Debug.LogError($"State Machine could not switch to unknown state \"{stateName}\", because it is not known from any of the specified transitions! That means the state machine would be stuck in this state forever if this were allowed!");
+    }
+
+    /// <summary>
+    /// This function adds a transition from a specific state.
+    /// </summary>
+    /// <param name="fromState">The state this transition can occur in.</param>
+    /// <param name="transition">A transition object that defines the state to transition into and the condition that must be met for this transition to occur.</param>
+    /// <exception cref="Exception">ArgumentNullException</exception>
+    public void AddTransitionFromState(IState fromState, Transition transition)
+    {
+        if (fromState == null)
+            throw new ArgumentNullException("The passed in from state is null!");
+        if (transition == null)
+            throw new ArgumentNullException("The passed in transition is null!");
+
+
+        // Check if there is already a list for this from state in the dictionary. If not, create one.
+        if (!_fromStateTransitions.ContainsKey(fromState.Name))
+            _fromStateTransitions.Add(fromState.Name, new List<Transition>());
+
+        // Add this transition into the appropriate list in the dictionary if it isn't already there.
+        if (!_fromStateTransitions[fromState.Name].Contains(transition))
+            _fromStateTransitions[fromState.Name].Add(transition);
+
+
+        // Add the from state to the states list if it isn't already there.
+        AddStateToLookupTables(fromState);
+
+        // Add the transition's target state to the states list if it isn't already there.
+        AddStateToLookupTables(transition.ToState);
+    }
+
+    /// <summary>
+    /// This function adds a transition that can occur from any other state.
+    /// </summary>
+    /// <param name="transition">A transition object that defines the state to transition into and the condition that must be met for this transition to occur.</param>
+    /// <exception cref="Exception">ArgumentNullException</exception>
+    public void AddTransitionFromAnyState(Transition transition)
+    {
+        if (transition == null)
+            throw new Exception("The passed in transition is null!");
+
+
+        if (!_fromAnyStateTransitions.Contains(transition))
+            _fromAnyStateTransitions.Add(transition);
+
+
+        // Add the transition's target state to the states list if it isn't already there.
+        AddStateToLookupTables(transition.ToState);
+    }
+
+    private void AddStateToLookupTables(IState state)
+    {
+        // Add the state to the states by name lookup table if it isn't already there.
+        if (!_statesByNameLookup.ContainsKey(state.Name))
+            _statesByNameLookup.Add(state.Name, state);
+
+        // Add the state to the states by type lookup table if it isn't already there.
+        if (!_statesByTypeLookup.ContainsKey(state.GetType()))
+            _statesByTypeLookup.Add(state.GetType(), state);
+    }
+
+
+
+    /// <summary>
+    /// If enabled, the SetState(IState state) method will let you set a state that is not already in the state machine's list,
+    /// and in this case it will add it to the list. Normally, the state machine knows about states from all transitions that have
+    /// been added. If you set a state that is not referenced by any transitions, then that means there is no way to leave said state
+    /// other than by calling SetState() again. As such, this option should probably be left off most of the time.
+    /// </summary>
+    public bool AllowUnknownStates = false;
+
+    /// <summary>
+    /// Returns the current state.
+    /// </summary>
+    public IState CurrentState { get { return _currentState; } }
+
+    /// <summary>
+    /// If enabled, the state machine will write a debug log every time it enters or exits a state, including the name of that state.
+    /// </summary>
+    public bool EnableDebugLogging { get; set; }
+
+    /// <summary>
+    /// Setting this to false will disable the state machine. It will simply bail out at the start of Update() so no other code is called.
+    /// </summary>
+    public bool IsEnabled { get; private set; }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachine/StateMachine.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachine/StateMachine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a381c3779cca78419bf814c3b35c05e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachine/StateMachineTester.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachine/StateMachineTester.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+public class StateMachineTester : MonoBehaviour
+{
+    StateMachine _stateMachine;
+
+    public int Value = 0;
+
+
+    private void Awake()
+    {
+        _stateMachine = GetComponent<StateMachine>();
+
+        State_TestStateA stateA = new State_TestStateA(this.gameObject);
+        State_TestStateB stateB = new State_TestStateB(this.gameObject);
+        State_TestStateC stateC = new State_TestStateC(this.gameObject);
+
+        Transition aToB = new Transition(stateB, TestCondition1);
+        Transition bToC = new Transition(stateC, TestCondition2);
+        Transition anyToA = new Transition(stateA, TestCondition0);
+
+        _stateMachine.AddTransitionFromState(stateA, aToB);
+        _stateMachine.AddTransitionFromState(stateB, bToC);
+
+        _stateMachine.AddTransitionFromAnyState(anyToA);
+
+        _stateMachine.SetState(stateA);
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyUp(KeyCode.Alpha0))
+            Value = 0;
+        else if (Input.GetKeyUp(KeyCode.Alpha1))
+            Value = 1;
+        else if (Input.GetKeyUp(KeyCode.Alpha2))
+            Value = 2;
+    }
+
+    public bool TestCondition0()
+    {
+        return Value == 0;
+    }
+
+    public bool TestCondition1()
+    {
+        return Value == 1;
+    }
+
+    public bool TestCondition2()
+    {
+        return Value == 2;
+    }
+
+}
+
+public class State_TestStateA : State_Base
+{
+    public State_TestStateA(GameObject parent)
+        : base(parent)
+    {
+
+    }
+
+}
+
+public class State_TestStateB : State_Base
+{
+    public State_TestStateB(GameObject parent)
+        : base(parent)
+    {
+
+    }
+
+}
+
+public class State_TestStateC : State_Base
+{
+    public State_TestStateC(GameObject parent)
+        : base(parent)
+    {
+
+    }
+
+}

--- a/Catpocalypse/Assets/Scripts/StateMachine/StateMachineTester.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachine/StateMachineTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0194ef5f47023f9418997e7c1476670e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachine/State_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachine/State_Base.cs
@@ -1,0 +1,37 @@
+﻿
+using UnityEngine;
+
+
+/// <summary>
+/// This is the base class that all state machine states have at the base of their inheritance heirarchy.
+/// </summary>
+public abstract class State_Base : IState
+{
+    // A reference to the object this state belongs to. This allows the state to manipulate the object by calling methods on it or setting properties.
+    protected GameObject _parent;
+
+
+
+    /// <summary>
+    /// The constructor.
+    /// </summary>
+    /// <param name="parentTower">The state needs a reference to its parent object so it can call methods on it.</param>
+    public State_Base(GameObject parent)
+    {
+        _parent = parent;
+    }
+
+
+    // These overridable methods are automatically called by the state machine.
+    public virtual void OnEnter() { Debug.Log($"Entered state \"{this.Name}\"."); }
+    public virtual void OnUpdate() { }
+    public virtual void OnExit() { Debug.Log($"Exited state \"{this.Name}\"."); }
+
+
+
+    /// <summary>
+    /// This property returns the C# class name of this state. This is useful when you need to check the current state of the state machine.
+    /// </summary>
+    public string Name { get { return this.GetType().Name; } }
+}
+

--- a/Catpocalypse/Assets/Scripts/StateMachine/State_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachine/State_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e259378de7950844bb5a8757a9726cfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachine/Transition.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachine/Transition.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+
+/// <summary>
+/// This delegate is used when calling a state machine state's constructor to
+/// tell it what function to call to check its transition condition.
+/// </summary>
+/// <returns>True if the associated condition is true.</returns>
+public delegate bool StateMachineConditionCheck();
+
+
+/// <summary>
+/// This class defines a transition in the state machine.
+/// </summary>
+public class Transition
+{
+    /// <summary>
+    /// The constructor.
+    /// </summary>
+    /// <param name="toState">The state that this transition will move the state machine into.</param>
+    /// <param name="conditionCheckDelegate">The delegate that checks the condition that's required for this transition to occur.</param>
+    public Transition(IState toState, StateMachineConditionCheck conditionCheckDelegate)
+    {
+        ToState = toState;
+        CheckTransitionCondition = conditionCheckDelegate;
+    }
+
+
+
+    public StateMachineConditionCheck CheckTransitionCondition { get; private set; }
+    public IState ToState { get; private set; }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachine/Transition.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachine/Transition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d72d86f720e25c49a97fdd333c6c01b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2a9f0799ea0ff34b970b83419aaf6d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Cats.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Cats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54f153ad36c32d34bbf25db2bc4ace3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Base.cs
@@ -1,0 +1,26 @@
+﻿
+using UnityEngine;
+
+
+/// <summary>
+/// This is the base class that all state machine states have at the base of their inheritance heirarchy.
+/// </summary>
+public abstract class CatState_Base : State_Base
+{
+    protected CatBase _parentCat;
+
+
+
+    /// <summary>
+    /// The constructor.
+    /// </summary>
+    /// <param name="parentCat">The state needs a reference to its parent cat so it can call methods on it.</param>
+    public CatState_Base(CatBase parentCat)
+        : base(parentCat.gameObject)
+    {
+        _parentCat = parentCat;
+    }
+
+
+}
+

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8598049d7aae0a479c6802f6a1164b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Idle_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Idle_Base.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+public class CatState_Idle_Base : CatState_Base
+{
+    public CatState_Idle_Base(CatBase parent)
+        : base(parent)
+    {
+
+    }
+
+
+    public override void OnEnter()
+    {
+
+    }
+
+    public override void OnExit()
+    {
+
+    }
+
+    public override void OnUpdate()
+    {
+
+    }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Idle_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Cats/CatState_Idle_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7aadc1ecc9eb3624fa670c1a23490e4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4081d432e0a952344aecb529c8be75d2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Active_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Active_Base.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+public class TowerState_Active_Base : TowerState_Base
+{
+    public TowerState_Active_Base(Tower parent)
+        : base(parent)
+    {
+
+    }
+
+
+    public override void OnEnter()
+    {
+        
+    }
+
+    public override void OnExit()
+    {
+        
+    }
+
+    public override void OnUpdate()
+    {
+        
+    }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Active_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Active_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8932cf4e2781fb547b3a448119a47bf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Base.cs
@@ -1,0 +1,26 @@
+﻿
+using UnityEngine;
+
+
+/// <summary>
+/// This is the base class that all state machine states have at the base of their inheritance heirarchy.
+/// </summary>
+public abstract class TowerState_Base : State_Base
+{
+    protected Tower _parentTower;
+
+
+
+    /// <summary>
+    /// The constructor.
+    /// </summary>
+    /// <param name="parentTower">The state needs a reference to its parent tower so it can call methods on it.</param>
+    public TowerState_Base(Tower parentTower)
+        : base(parentTower.gameObject)
+    {
+        _parentTower = parentTower;
+    }
+
+
+}
+

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13d5a4959c12ad4468be7586bf364a48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Disabled_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Disabled_Base.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+public class TowerState_Disabled_Base : TowerState_Base
+{
+    public TowerState_Disabled_Base(Tower parent)
+        : base(parent)
+    {
+
+    }
+
+
+    public override void OnEnter()
+    {
+
+    }
+
+    public override void OnExit()
+    {
+
+    }
+
+    public override void OnUpdate()
+    {
+
+    }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Disabled_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Disabled_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43f3a1afc74aae64baba9f20a0a34b6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Idle_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Idle_Base.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+public class TowerState_Idle_Base : TowerState_Base
+{
+    public TowerState_Idle_Base(Tower parent)
+        : base(parent)
+    {
+
+    }
+
+
+    public override void OnEnter()
+    { 
+
+    }
+
+    public override void OnExit()
+    {
+
+    }
+
+    public override void OnUpdate()
+    {
+
+    }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Idle_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Idle_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 856ce15d3a0d46a4ca0242f3286f775b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Upgrading_Base.cs
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Upgrading_Base.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+public class TowerState_Upgrading_Base : TowerState_Base
+{
+    public TowerState_Upgrading_Base(Tower parent)
+        : base(parent)
+    {
+
+    }
+
+
+    public override void OnEnter()
+    {
+
+    }
+
+    public override void OnExit()
+    {
+
+    }
+
+    public override void OnUpdate()
+    {
+
+    }
+}

--- a/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Upgrading_Base.cs.meta
+++ b/Catpocalypse/Assets/Scripts/StateMachineStates/Towers/TowerState_Upgrading_Base.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8af85eb22a2712428592fe7cb926810
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/UserSettings/EditorUserSettings.asset
+++ b/Catpocalypse/UserSettings/EditorUserSettings.asset
@@ -6,25 +6,25 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedSceneGuid-0:
-      value: 500957045d56085d55565c2713720c444e4f417a7d2b72347f2f4860b2e3313a
-      flags: 0
-    RecentlyUsedSceneGuid-1:
-      value: 5a08505f54500c5f5f0a0f7713745a44414e48792a2b24697b7a1e66bae2663c
-      flags: 0
-    RecentlyUsedSceneGuid-2:
       value: 5a5757560101590a5d0c0e24427b5d44434e4c7a7b7a23677f2b4565b7b5353a
       flags: 0
+    RecentlyUsedSceneGuid-1:
+      value: 075357055605590e5a575c7616270944464f497b2a717e642c78456bb0b76d6c
+      flags: 0
+    RecentlyUsedSceneGuid-2:
+      value: 075357055605590e5a575c7616270944464f497b2a717e642c78456bb0b76d6c
+      flags: 0
     RecentlyUsedSceneGuid-3:
-      value: 075357055605590e5a575c7616270944464f497b2a717e642c78456bb0b76d6c
-      flags: 0
-    RecentlyUsedSceneGuid-4:
-      value: 075357055605590e5a575c7616270944464f497b2a717e642c78456bb0b76d6c
-      flags: 0
-    RecentlyUsedSceneGuid-5:
       value: 0609005552570d08080f097516720744124f4c282e7124647a2c1f37b6e1366b
       flags: 0
-    RecentlyUsedSceneGuid-6:
+    RecentlyUsedSceneGuid-4:
       value: 5454505453045a0e5456557640770e444e1619292a2970617c7b4b6be3e1656c
+      flags: 0
+    RecentlyUsedSceneGuid-5:
+      value: 5a08505f54500c5f5f0a0f7713745a44414e48792a2b24697b7a1e66bae2663c
+      flags: 0
+    RecentlyUsedSceneGuid-6:
+      value: 500957045d56085d55565c2713720c444e4f417a7d2b72347f2f4860b2e3313a
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650

--- a/Catpocalypse/UserSettings/Layouts/default-2022.dwlt
+++ b/Catpocalypse/UserSettings/Layouts/default-2022.dwlt
@@ -14,16 +14,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_PixelRect:
     serializedVersion: 2
-    x: 1281
-    y: 51
-    width: 1278
-    height: 1348
+    x: 0
+    y: 43
+    width: 2560
+    height: 1357
   m_ShowMode: 4
   m_Title: Project
   m_RootView: {fileID: 2}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
-  m_Maximized: 0
+  m_Maximized: 1
 --- !u!114 &2
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -44,8 +44,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1278
-    height: 1348
+    width: 2560
+    height: 1357
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_UseTopView: 1
@@ -69,7 +69,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1278
+    width: 2560
     height: 30
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
@@ -90,8 +90,8 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 1328
-    width: 1278
+    y: 1337
+    width: 2560
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
@@ -114,12 +114,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 30
-    width: 1278
-    height: 1298
+    width: 2560
+    height: 1307
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 50538
+  controlID: 17
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -139,12 +139,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1015
-    height: 1298
+    width: 2033
+    height: 1307
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 50539
+  controlID: 18
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -164,12 +164,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1015
-    height: 764
+    width: 2033
+    height: 769
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 50540
+  controlID: 19
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -187,10 +187,10 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 207
-    height: 764
-  m_MinSize: {x: 200, y: 200}
-  m_MaxSize: {x: 4000, y: 4000}
+    width: 415
+    height: 769
+  m_MinSize: {x: 201, y: 221}
+  m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 13}
   m_Panes:
   - {fileID: 13}
@@ -211,10 +211,10 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 207
+    x: 415
     y: 0
-    width: 808
-    height: 764
+    width: 1618
+    height: 769
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
   m_ActualView: {fileID: 14}
@@ -240,9 +240,9 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 764
-    width: 1015
-    height: 534
+    y: 769
+    width: 2033
+    height: 538
   m_MinSize: {x: 231, y: 271}
   m_MaxSize: {x: 10001, y: 10021}
   m_ActualView: {fileID: 16}
@@ -266,12 +266,12 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1015
+    x: 2033
     y: 0
-    width: 263
-    height: 1298
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
+    width: 527
+    height: 1307
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 18}
   m_Panes:
   - {fileID: 18}
@@ -298,9 +298,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 414
+    x: 415
     y: 73
-    width: 1617
+    width: 1616
     height: 748
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -315,7 +315,7 @@ MonoBehaviour:
   m_SerializedViewNames: []
   m_SerializedViewValues: []
   m_PlayModeViewName: GameView
-  m_ShowGizmos: 0
+  m_ShowGizmos: 1
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
   m_TargetSize: {x: 1292, y: 727}
@@ -325,7 +325,7 @@ MonoBehaviour:
   m_EnterPlayModeBehavior: 0
   m_UseMipMap: 0
   m_VSyncEnabled: 0
-  m_Gizmos: 0
+  m_Gizmos: 1
   m_Stats: 0
   m_SelectedSizes: 01000000000000000000000000000000000000000000000000000000000000000000000000000000
   m_ZoomArea:
@@ -354,23 +354,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 1617
+      width: 1616
       height: 727
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 808.5, y: 363.5}
+    m_Translation: {x: 808, y: 363.5}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -808.5
+      x: -808
       y: -363.5
-      width: 1617
+      width: 1616
       height: 727
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 1617, y: 748}
+  m_LastWindowPixelSize: {x: 1616, y: 748}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
@@ -396,10 +396,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1281
-    y: 81
-    width: 206
-    height: 743
+    x: 0
+    y: 73
+    width: 414
+    height: 748
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -415,7 +415,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: e686feff4695feffbcaafeff1ec9feffe6cafeff4cccfeff60cffeffbcd0feff34d2feff8cd7feffc8fefeffe40effff900fffffba17ffff7436ffff725affff8c5affffa05afffff474ffff6cc3ffffdee5ffffe2f2ffff40f8ffff8ef9ffff0afbffff26600000306000006e8a0000768a00008a8a0000e68a0000fc8a0000108b00003c8b00005e8b0000828b000028ae000054b000006eb0000098b00000c0b0000000b10000
+      m_ExpandedIDs: 78ddffff90e9ffff0afbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -459,10 +459,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1488
-    y: 81
-    width: 806
-    height: 743
+    x: 415
+    y: 73
+    width: 1616
+    height: 748
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -834,9 +834,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 465.18457, y: -15.441855, z: 2205.8257}
+    m_Target: {x: 31.85051, y: -3135.8132, z: 2642.2969}
     speed: 2
-    m_Value: {x: 465.18457, y: -15.441855, z: 2205.8257}
+    m_Value: {x: 31.85051, y: -3135.8132, z: 2642.2969}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -882,13 +882,13 @@ MonoBehaviour:
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: -0.11259085, y: 0.008479402, z: 0.000014270063, w: -0.9937919}
+    m_Target: {x: -0.42176676, y: -0.00014221664, z: 0.0010551324, w: -0.9069139}
     speed: 2
-    m_Value: {x: -0.112569965, y: 0.008477829, z: 0.000014267416, w: -0.9936076}
+    m_Value: {x: -0.42168644, y: -0.00014218956, z: 0.0010549314, w: -0.90674114}
   m_Size:
-    m_Target: 1539.3093
+    m_Target: 2077.8708
     speed: 2
-    m_Value: 1539.3093
+    m_Value: 2077.8708
   m_Ortho:
     m_Target: 0
     speed: 2
@@ -967,10 +967,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1281
-    y: 845
-    width: 1014
-    height: 513
+    x: 0
+    y: 842
+    width: 2032
+    height: 517
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -992,7 +992,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Resources/TowersInfo
+    - Assets/Scripts/StateMachine
     m_Globs: []
     m_OriginalText: 
     m_ImportLogFlags: 0
@@ -1000,16 +1000,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/Resources/TowersInfo
+  - Assets/Scripts/StateMachine
   m_LastFoldersGridSize: 16
   m_LastProjectPath: F:\GameDev Projects\P1OC\Catpocalypse\Catpocalypse
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: f0640000
-    m_LastClickedID: 25840
-    m_ExpandedIDs: 00000000a25f0000a45f0000c05f0000c45f000000ca9a3b
+    m_SelectedIDs: fa770000
+    m_LastClickedID: 30714
+    m_ExpandedIDs: 00000000286e0000386e00003e6e000000ca9a3b
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1037,7 +1037,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000a25f0000a45f000000ca9a3b
+    m_ExpandedIDs: 00000000286e0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1068,18 +1068,18 @@ MonoBehaviour:
     m_ExpandedInstanceIDs: c62300003a62000000000000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
+      m_Name: StateMachine
+      m_OriginalName: StateMachine
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 0
+      m_UserData: 30726
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 11
+      m_OriginalEventType: 0
       m_IsRenamingFilename: 1
       m_ClientGUIView: {fileID: 10}
     m_CreateAssetUtility:
@@ -1113,10 +1113,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1281
-    y: 845
-    width: 1014
-    height: 513
+    x: 0
+    y: 842
+    width: 2032
+    height: 517
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1147,10 +1147,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 2296
-    y: 81
-    width: 262
-    height: 1277
+    x: 2033
+    y: 73
+    width: 526
+    height: 1286
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1214,7 +1214,7 @@ MonoBehaviour:
     m_CachedPref: 151
     m_ControlHash: 1412526313
     m_PrefName: Preview_InspectorPreview
-  m_LastInspectedObjectInstanceID: 24142
+  m_LastInspectedObjectInstanceID: 30726
   m_LastVerticalScrollValue: 0
   m_GlobalObjectId: 
   m_InspectorMode: 0


### PR DESCRIPTION
I added the `[RequireComponent(typeof(StateMachine))]` attribute to both CatBase.cs and Tower.cs. This way all cats and towers automatically have a state machine now. I also added a virtual method in both, called `InitStateMachine()`. Subclasses can override this function to initialize the state machine however they like.

I also added a couple of public options. Setting `StateMachine.EnableDebugLogging` to true will cause it to write to the console every time it exits or enters a state. That way you can easily see what is going on when debugging.

The other setting is `StateMachine.AllowUnknownStates`. When set to true, you can pass a state into `StateMachine.SetState()` that is not referenced by any transitions. Normally this isn't allowed since it means the only way to change states is via `SetState()`. However, if you have no transitions, this option needs to be enabled, or the state machine will throw an exception since the state won't be on its list. That's because it hasn't seen it in any transitions that were added.

So yeah, if you want to use the state machine without the automatic transitions, turn on `StateMachine.AllowUnknownStates`.