### PR TITLE
Tower bug fixes

### DIFF
--- a/Catpocalypse/Assets/Prefabs/Towers/NonAllergicPerson.prefab
+++ b/Catpocalypse/Assets/Prefabs/Towers/NonAllergicPerson.prefab
@@ -131,7 +131,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e605d2cc970259e408f1a5efc7edcc2c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  effectLength: 1
+  effectLength: 3
 --- !u!135 &7521085383306290925
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/Towers/Nyan scratching post launcher Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Towers/Nyan scratching post launcher Variant.prefab
@@ -148,7 +148,7 @@ MonoBehaviour:
   refundPercentage: 0.85
   range: {fileID: 8975065090706773128}
   distractValue: 8
-  numberOfTargets: 282
+  numberOfTargets: 0
   targets: []
   towerLevel: 1
   upgradeCost: 0
@@ -157,6 +157,8 @@ MonoBehaviour:
   _IrScratchPost: {fileID: 354219167358990314, guid: 8ae07f1517e833d42b835dc0ccc97f2a, type: 3}
   _TimeBetweenLaunches: 1
   postCount: 0
+  AOEUpgrade: 5
+  debuffUpgrade: 5
 --- !u!23 &6451762848420790279
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Scripts/Cat/CatBase.cs
+++ b/Catpocalypse/Assets/Scripts/Cat/CatBase.cs
@@ -211,9 +211,6 @@ public class CatBase : MonoBehaviour
             float debuffPercent = PlayerCutenessManager.Instance.CuteChallenge_CatsGetHarderToDistract_DebuffPercent;
             distractionValue = distractionValue * debuffPercent;
         }
-
-
-
         distraction += distractionValue;
         UpdateDistractednessMeter();
 

--- a/Catpocalypse/Assets/Scripts/Towers/IrresistableScratchingPost.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/IrresistableScratchingPost.cs
@@ -124,8 +124,8 @@ public class IrresistableScratchingPost : MonoBehaviour
                 {
                     CatBase cat = obj.GetComponent<CatBase>();
                     cat.DistractCat(
-                        gameObject.GetComponentInParent<ScratchingPostTower>().DistractValue,
-                        gameObject.GetComponentInParent<ScratchingPostTower>()
+                        parentTower.GetComponent<ScratchingPostTower>().DistractValue,
+                        parentTower.GetComponent<ScratchingPostTower>()
                         );
                     RemoveDurability();
                 }

--- a/Catpocalypse/Assets/Scripts/Towers/IrresistableScratchingPost.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/IrresistableScratchingPost.cs
@@ -109,12 +109,13 @@ public class IrresistableScratchingPost : MonoBehaviour
         }
         else
         {
+            DistractCats();
             yield return new WaitForSeconds(_DurationTickTime);
             StartCoroutine(DurationCountDown(--currentTimeLeft));
         }
     }
 
-    private IEnumerator DistractCats()
+    private void DistractCats()
     {
         if (_Cats.Count > 0)
         {
@@ -134,8 +135,7 @@ public class IrresistableScratchingPost : MonoBehaviour
                     _Cats.Remove(obj);
                 }
             }
-            yield return new WaitForSeconds(_DurationTickTime);
-            StartCoroutine(DistractCats());
+           
         }
     }
 }

--- a/Catpocalypse/Assets/Scripts/Towers/NonAllergicPerson.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/NonAllergicPerson.cs
@@ -8,7 +8,7 @@ public class NonAllergicPerson : MonoBehaviour
 {
     private NavMeshAgent agent;
     private Tower tower; //The parent tower
-    private bool isPetting = false;
+    private bool isPetting = false; //Is the person petting a cat
     private GameObject target;
     private List<GameObject> pastTargets; //Cats that the person has already petted
     private List<GameObject> catsInRange; //The cats that are in range of the collider
@@ -106,9 +106,12 @@ public class NonAllergicPerson : MonoBehaviour
 
     IEnumerator PetCat()
     {
+        //target.GetComponent<CatBase>().stoppingEntities.Add(gameObject);
+        isPetting = true;
         StartCoroutine(DistractOverTime());
         pastTargets.Add(target);
         yield return new WaitForSeconds(effectLength);
+        target.GetComponent<CatBase>().stoppingEntities.Remove(gameObject);
         RemoveTarget();
     }
 
@@ -127,7 +130,7 @@ public class NonAllergicPerson : MonoBehaviour
 
     IEnumerator DistractOverTime()
    {
-     
+        
         if(isPetting && target != null)
         {
             target.GetComponent<CatBase>().DistractCat(tower.DistractValue, tower);

--- a/Catpocalypse/Assets/Scripts/Towers/ScratchingPost.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/ScratchingPost.cs
@@ -32,7 +32,7 @@ public class ScratchingPost : MonoBehaviour
     [Min(0f)]
     private float _DurabilityRemovedByCat;
 
-    private List<GameObject> _Cats = new List<GameObject>();
+    private List<GameObject> _Cats;
 
     private bool _Destroying = false;
 
@@ -40,6 +40,7 @@ public class ScratchingPost : MonoBehaviour
 
     public void Start()
     {
+        _Cats = new List<GameObject>();
         StartCoroutine(DurationCountDown(_Duration));
     }
 
@@ -114,13 +115,15 @@ public class ScratchingPost : MonoBehaviour
         }
         else
         {
+            DistractCats();
             yield return new WaitForSeconds(_DurationTickTime);
             StartCoroutine(DurationCountDown(--currentTimeLeft));
         }
     }
 
-    private IEnumerator DistractCats()
+    private void DistractCats()
     {
+        
         if (_Cats.Count > 0)
         {
             foreach (GameObject obj in _Cats)
@@ -129,8 +132,8 @@ public class ScratchingPost : MonoBehaviour
                 {
                     CatBase cat = obj.GetComponent<CatBase>();
                     cat.DistractCat(
-                        gameObject.GetComponentInParent<ScratchingPostTower>().DistractValue,
-                        gameObject.GetComponentInParent<ScratchingPostTower>()
+                        parentTower.GetComponent<ScratchingPostTower>().DistractValue,
+                        parentTower.GetComponent<ScratchingPostTower>()
                         );
                     RemoveDurability();
                 }
@@ -139,8 +142,8 @@ public class ScratchingPost : MonoBehaviour
                     _Cats.Remove(obj);
                 }
             }
-            yield return new WaitForSeconds(_DurationTickTime);
-            StartCoroutine(DistractCats());
         }
+        
+        
     }
 }

--- a/Catpocalypse/Assets/Scripts/Towers/ScratchingPostTower.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/ScratchingPostTower.cs
@@ -36,17 +36,9 @@ public class ScratchingPostTower : Tower
     public int postCount = 0;
     private float IrCooldown = 8;
     private bool ISPReady = false;
-    [SerializeField, Tooltip("How much the upgrade increases the scratching post tower AOE")]
-    private float AOEUpgrade = 5;
-    [SerializeField, Tooltip("How much the upgrade increases the scratching post tower speed debuff")]
-    private float debuffUpgrade = 5;
-
-    private float speedDebuff;
-    private float AOE;
     private void Start()
     {
-        speedDebuff = _ScratchPost.GetComponent<ScratchingPost>().speedDebuff;
-        AOE = _ScratchPost.GetComponent<SphereCollider>().radius;
+        
     }
     public void Update()
     {
@@ -103,14 +95,13 @@ public class ScratchingPostTower : Tower
             
             GameObject post = Instantiate(_ScratchPost, destination, Quaternion.identity);
             post.GetComponent<ScratchingPost>().parentTower = gameObject;
-            post.GetComponent<SphereCollider>().radius = AOE;
-            post.GetComponent<ScratchingPost>().speedDebuff = speedDebuff;
+            
         }
         else
         {
             GameObject post = Instantiate(_IrScratchPost, destination, Quaternion.identity);
             post.GetComponent<IrresistableScratchingPost>().parentTower = gameObject;
-            post.GetComponent<SphereCollider>().radius = AOE;
+           
             StartCoroutine(ISPCooldown());
         }
         


### PR DESCRIPTION
I fixed the bugs where the Non-Allergic tower and the scratching post tower were not doing damage. For the Non-Allergic tower, the problem was a boolean not being set to true. For the scratching post tower, the problem was that the scratching post is not actually a child of the tower, so it was not getting what it needed for the DistractCat function. I made it get the ScratchingPostTower component from the parentTower variable instead of the GetCompononentInParent function.