### PR TITLE
Added loading screen random messages

### DIFF
--- a/Catpocalypse/Assets/Resources/Loading Screen.prefab
+++ b/Catpocalypse/Assets/Resources/Loading Screen.prefab
@@ -1,5 +1,139 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &85521980154747198
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1768616140471643975}
+  - component: {fileID: 2570350914799243435}
+  - component: {fileID: 3127026240733266032}
+  m_Layer: 5
+  m_Name: Press Any Key Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1768616140471643975
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85521980154747198}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4617783931721686310}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 100}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2570350914799243435
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85521980154747198}
+  m_CullTransparentMesh: 1
+--- !u!114 &3127026240733266032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85521980154747198}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Press any button...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 79459efec17a4d00a321bdcc27bbc385, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1197201708395641864
 GameObject:
   m_ObjectHideFlags: 0
@@ -12,7 +146,7 @@ GameObject:
   - component: {fileID: 5208614350929088672}
   - component: {fileID: 737193146703114435}
   m_Layer: 5
-  m_Name: Loading Screen Image
+  m_Name: Image
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -34,7 +168,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 960, y: -388.42593}
+  m_AnchoredPosition: {x: 960, y: -250}
   m_SizeDelta: {x: 1720, y: 776.85187}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5208614350929088672
@@ -101,7 +235,9 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5711765046327066837}
+  - {fileID: 8597334999235526185}
   - {fileID: 8119367412673030522}
+  - {fileID: 1768616140471643975}
   m_Father: {fileID: 802551091145493325}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -276,9 +412,143 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4215925838137170822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8597334999235526185}
+  - component: {fileID: 2419126633505590212}
+  - component: {fileID: 2412489770431370906}
+  m_Layer: 5
+  m_Name: Message Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8597334999235526185
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4215925838137170822}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4617783931721686310}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: -200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2419126633505590212
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4215925838137170822}
+  m_CullTransparentMesh: 1
+--- !u!114 &2412489770431370906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4215925838137170822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: <message text>
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 79459efec17a4d00a321bdcc27bbc385, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4290968831
+  m_fontColor: {r: 1, g: 0.9898358, b: 0.759434, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 35
+  m_fontSizeBase: 35
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4486802015819943055
 GameObject:
   m_ObjectHideFlags: 0
@@ -563,6 +833,34 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _ProgressBar: {fileID: 7137444221517322341}
   _ProgressBarText: {fileID: 8319828641192538642}
+  _LoadingScreenMessageText: {fileID: 2412489770431370906}
+  _PressAnyKeyText: {fileID: 3127026240733266032}
+  _WaitForButtonPressToCloseLoadingScreen: 1
+  _UseLoadingScreenCloseDelay: 1
+  _LoadingScreenCloseDelay: 5
+  _LoadingScreenMessages:
+  - Soft kitty, warm kitty, little ball of fur. Raged kitty, martial kitty, war,
+    war, war!
+  - Cats can get frightened by cucumbers? To this day it remains one of life's great
+    mysteries.
+  - Playing with cats using a laser pointer is all fun and games, until someone points
+    the laser at your face.
+  - Ever wonder what cats dream about? Probably world domination.
+  - Whenever a cat plays with a yarn ball, a granny somewhere faints.
+  - Most cats prefer cardboxes over pricey cat-houses, mostly because they like seeing
+    their owners pissed and bankrupt.
+  - It's rumored that cats see ghosts when they stare at nothing. In truth they simply
+    enjoy messing with humans.
+  - Napping may be a human invention, but it is cats that have perfected it.
+  - In Ancient Egypt, cats were revered as gods. In today's world, cats are still
+    revered as gods, and they know it.
+  - Cats don't have owners, they have staff.
+  - Cats are notorious for knocking things off tables, but they only do it out of
+    pure spite. Against you. Yes, you specifically.
+  - If the world were flat, cats would've knocked everything off the edge by now.
+  - Cats will never understand what people see in dogs. So the cat is forever plotting
+    the dog's demise.
+  - Cats don't like lasagna as much as you think they do.
 --- !u!1 &6789800136651459647
 GameObject:
   m_ObjectHideFlags: 0
@@ -867,7 +1165,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 5136165595559602711}
   m_FillRect: {fileID: 1646800425202519890}
   m_HandleRect: {fileID: 0}
@@ -875,7 +1173,7 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0.66
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Catpocalypse/Assets/Scripts/UI/SceneLoader_Async.cs
+++ b/Catpocalypse/Assets/Scripts/UI/SceneLoader_Async.cs
@@ -1,11 +1,17 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using UnityEngine;
 using UnityEngine.UI;
-using TMPro;
 using UnityEngine.SceneManagement;
-using System.Threading.Tasks;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Utilities;
+using UnityEditor;
+using TMPro;
+
+using Random = UnityEngine.Random;
 
 
 public class SceneLoader_Async : MonoBehaviour
@@ -14,11 +20,36 @@ public class SceneLoader_Async : MonoBehaviour
 
 
     [Header("UI References")]
+
     [SerializeField] private Slider _ProgressBar;
     [SerializeField] private TextMeshProUGUI _ProgressBarText;
+    [SerializeField] private TextMeshProUGUI _LoadingScreenMessageText;
+    [SerializeField] private TextMeshProUGUI _PressAnyKeyText;
+
+
+    [Header("Settings")]
+
+    [Tooltip("If enabled, the loading screen will stay open until the user presses any key. If UseLoadingScreenCloseDelay is also enabled, then the loading screen will close either when the user presses any button or when the delay expires, so whichever happens first.")]
+    [SerializeField] private bool _WaitForButtonPressToCloseLoadingScreen = true;
+    
+    [Space(10)]
+    
+    [Tooltip("If enabled, the loading screen will wait have a delay before closing after the next scene finishes loading. The length of this delay is specifed by the LoadingScreenCloseDelay setting.")]
+    [SerializeField] private bool _UseLoadingScreenCloseDelay;
+    [Tooltip("If UseLoadingScreenCloseDelay is enabled, this sets how long to wait after the next scene finishes loading before the loading screen should close.")]
+    [SerializeField] private float _LoadingScreenCloseDelay = 5f;
+
+    [Space(10)]
+
+    [Tooltip("This list specifies all of the random messages that can appear on the loading screen.")]
+    [SerializeField] private List<string> _LoadingScreenMessages;
 
 
     private static bool IsLoadingScreenActive;
+
+    private static bool ReceivedInput;
+
+    IDisposable _UserInputListener;
 
 
 
@@ -34,6 +65,12 @@ public class SceneLoader_Async : MonoBehaviour
 
         Instance = this;
 
+        // This will only be displayed if _WaitForButtonPressToCloseLoadingScreen is set to true.
+        _PressAnyKeyText.gameObject.SetActive(false);
+
+        // Listen for user input
+        _UserInputListener = InputSystem.onAnyButtonPress.Call(OnAnyInput);
+
         // Tell Unity to not destroy this game object when a new scene is loaded.
         DontDestroyOnLoad(gameObject);
     }
@@ -47,6 +84,10 @@ public class SceneLoader_Async : MonoBehaviour
         }
     }
 
+    private void OnDestroy()
+    {
+        _UserInputListener?.Dispose();
+    }
 
     public static void LoadSceneAsync(string sceneToLoad)
     {
@@ -72,9 +113,16 @@ public class SceneLoader_Async : MonoBehaviour
             return;
         }
 
+        // Select a randome message.
+        int index = Random.Range(0, _LoadingScreenMessages.Count);
 
+        // Display the randomly selected message.
+        _LoadingScreenMessageText.text = _LoadingScreenMessages[index];
+
+        // Enable the loading screen GameObject.
         gameObject.SetActive(true);
         
+        // Start loading the specified scene.
         StartCoroutine(LoadScene(sceneToLoad));        
     }
 
@@ -85,8 +133,10 @@ public class SceneLoader_Async : MonoBehaviour
         _ProgressBar.value = 0f;
         _ProgressBarText.text = "0%";
 
+        // Start loading the specified scene asynchonrously.
         AsyncOperation loadOperation = SceneManager.LoadSceneAsync(sceneToLoad);
 
+        // Wait while the scene loads and show progress.
         while (!loadOperation.isDone)
         {
             float progress = loadOperation.progress / 1.0f;
@@ -96,7 +146,51 @@ public class SceneLoader_Async : MonoBehaviour
         }
 
 
+        // I added these two lines just because the progress won't necessarily by at exactly 100% after the above loop.
+        _ProgressBar.value = 1f;
+        _ProgressBarText.text = "100%";
+
+        // If the option is enabled, then keep the loading screen up until the user presses any button.
+        if (_WaitForButtonPressToCloseLoadingScreen || _UseLoadingScreenCloseDelay)
+        {
+            ReceivedInput = false;
+            float timer = 0f;
+
+            // If _WaitForButtonPressToCloseLoadingScreen is enabled, then wait until the user presses any button before closing the loading screen.
+            // If _UseLoadingScreenCloseDelay is enabled, the wait for the specified delay time before closing the loading screen.
+            // If both options are enabled, the loading screen will close either when the user presses any button or when the delay expires, so whichever happens first.
+            while (true)                   
+            {
+                // If _WaitForButtonPressToCloseLoadingScreen is enabled, then wait until the user presses any button before closing the loading screen.
+                if (_WaitForButtonPressToCloseLoadingScreen && ReceivedInput)
+                {
+                    break;
+                }
+
+                // If _UseLoadingScreenCloseDelay is enabled, the wait for the specified delay time before closing the loading screen.
+                timer += Time.deltaTime;
+                if (_UseLoadingScreenCloseDelay && timer > _LoadingScreenCloseDelay)
+                {
+                    break;
+                }
+
+
+                // Wait one frame.
+                yield return null; 
+
+            } // end while
+
+            ReceivedInput = false;
+        }
+
+
+        // Close the loading screen.
         IsLoadingScreenActive = false;
         gameObject.SetActive(false);
+    }
+
+    private void OnAnyInput(InputControl control)
+    {
+        ReceivedInput = true;
     }
 }

--- a/Catpocalypse/UserSettings/EditorUserSettings.asset
+++ b/Catpocalypse/UserSettings/EditorUserSettings.asset
@@ -9,25 +9,25 @@ EditorUserSettings:
       value: 5a5757560101590a5d0c0e24427b5d44434e4c7a7b7a23677f2b4565b7b5353a
       flags: 0
     RecentlyUsedSceneGuid-1:
-      value: 0609005552570d08080f097516720744124f4c282e7124647a2c1f37b6e1366b
-      flags: 0
-    RecentlyUsedSceneGuid-2:
       value: 5553005e5d0508590c5c0d2113770b4442151d2e7f787f61297b4e36b4b1636c
       flags: 0
-    RecentlyUsedSceneGuid-3:
+    RecentlyUsedSceneGuid-2:
       value: 075357055605590e5a575c7616270944464f497b2a717e642c78456bb0b76d6c
       flags: 0
-    RecentlyUsedSceneGuid-4:
+    RecentlyUsedSceneGuid-3:
       value: 500957045d56085d55565c2713720c444e4f417a7d2b72347f2f4860b2e3313a
       flags: 0
-    RecentlyUsedSceneGuid-5:
+    RecentlyUsedSceneGuid-4:
       value: 5454505453045a0e5456557640770e444e1619292a2970617c7b4b6be3e1656c
       flags: 0
-    RecentlyUsedSceneGuid-6:
+    RecentlyUsedSceneGuid-5:
       value: 5a08505f54500c5f5f0a0f7713745a44414e48792a2b24697b7a1e66bae2663c
       flags: 0
-    RecentlyUsedSceneGuid-7:
+    RecentlyUsedSceneGuid-6:
       value: 5454505453045a0e5456557640770e444e1619292a2970617c7b4b6be3e1656c
+      flags: 0
+    RecentlyUsedSceneGuid-7:
+      value: 0609005552570d08080f097516720744124f4c282e7124647a2c1f37b6e1366b
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
+ The loading screen prefab now has a list of strings in the inspector so the list of random load screen messages is super easy to customize.
+ Added options in the inspector for the loading screen so it is now super easy to make it wait for user input before closing, or wait for a specifc delay after the scene has finished loading. If both options are on, then it will close on whichever thing happens first, user input or the delay elapsing.
+ Fixed a bug where the bar didn't reach 100%
+ Fixed a bug where you could drag the progress bar around because I forgot to disable its Interactable setting.