### PR TITLE
Nav System Overhaul

### DIFF
--- a/Catpocalypse/Assets/Prefabs/Cats/Boarding cat Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/Boarding cat Variant.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 3325332961720871933}
   - component: {fileID: 797072595149710763}
   - component: {fileID: 3226867234852970270}
+  - component: {fileID: -5027761021249892969}
   m_Layer: 3
   m_Name: Boarding cat Variant
   m_TagString: Cat
@@ -77,8 +78,7 @@ MonoBehaviour:
   distractionThreshold: 75
   damageToPlayer: 1
   speed: 0
-  _WayPointArrivedDistance: 6
-  agent: {fileID: 0}
+  NavController: {fileID: -5027761021249892969}
   distractReward: 14
   _DistractednessMeterHeightAboveCat: 8
   _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
@@ -284,6 +284,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AllowUnknownStates: 0
+--- !u!114 &-5027761021249892969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2247931869541265458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0760ac38ef6c51439504cf1bd752a09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _WayPointArrivedDistance: 1
+  agent: {fileID: 354537596788895851}
 --- !u!1001 &5466515255480137670
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/Cats/Card board catNormal1 Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/Card board catNormal1 Variant.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 5570907850504849197}
   - component: {fileID: 8672021303309095243}
   - component: {fileID: 6837119006567958781}
+  - component: {fileID: -1474306262221267380}
   m_Layer: 3
   m_Name: Card board catNormal1 Variant
   m_TagString: Cat
@@ -90,8 +91,7 @@ MonoBehaviour:
   distractionThreshold: 200
   damageToPlayer: 5
   speed: 0
-  _WayPointArrivedDistance: 2
-  agent: {fileID: -2116463544244376725, guid: 87b750aa9cfe0c1498a2348ee619a2ce, type: 3}
+  NavController: {fileID: -1474306262221267380}
   distractReward: 50
   _DistractednessMeterHeightAboveCat: 2
   _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
@@ -284,6 +284,20 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &-1474306262221267380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2914954983465273623}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0760ac38ef6c51439504cf1bd752a09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _WayPointArrivedDistance: 1
+  agent: {fileID: 2074363123680958709}
 --- !u!1001 &8179961966997294007
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/Cats/Chonky cat Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/Chonky cat Variant.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 413558794927069452}
   - component: {fileID: -3415287471716158527}
   - component: {fileID: 7474505534065298321}
+  - component: {fileID: 8495146473585950369}
   m_Layer: 3
   m_Name: Chonky cat Variant
   m_TagString: Cat
@@ -77,8 +78,7 @@ MonoBehaviour:
   distractionThreshold: 150
   damageToPlayer: 3
   speed: 0
-  _WayPointArrivedDistance: 2
-  agent: {fileID: 0}
+  NavController: {fileID: 8495146473585950369}
   distractReward: 22
   _DistractednessMeterHeightAboveCat: 8
   _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
@@ -284,6 +284,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AllowUnknownStates: 0
+--- !u!114 &8495146473585950369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5758637314826502625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0760ac38ef6c51439504cf1bd752a09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _WayPointArrivedDistance: 1
+  agent: {fileID: 3113796196340654419}
 --- !u!1001 &763332245122486805
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/Cats/NormalCat.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/NormalCat.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 4258398137405455121}
   - component: {fileID: 4483574012576929532}
   - component: {fileID: 4271309147003016060}
+  - component: {fileID: -705044849001712320}
   m_Layer: 3
   m_Name: NormalCat
   m_TagString: Cat
@@ -125,8 +126,7 @@ MonoBehaviour:
   distractionThreshold: 100
   damageToPlayer: 2
   speed: 0
-  _WayPointArrivedDistance: 4
-  agent: {fileID: 0}
+  NavController: {fileID: -705044849001712320}
   distractReward: 8
   _DistractednessMeterHeightAboveCat: 8
   _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
@@ -284,6 +284,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AllowUnknownStates: 0
+--- !u!114 &-705044849001712320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1589074876568128993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0760ac38ef6c51439504cf1bd752a09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _WayPointArrivedDistance: 1
+  agent: {fileID: 4388902454001029155}
 --- !u!1001 &2985846187281833752
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Catpocalypse/Assets/Prefabs/Cats/chonky box ccat Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Cats/chonky box ccat Variant.prefab
@@ -234,6 +234,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 31cce6d45ec1f8e4db15560b3b017c9b, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1699814510724812543}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 31cce6d45ec1f8e4db15560b3b017c9b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -351561568029942122}
   m_SourcePrefab: {fileID: 100100000, guid: 31cce6d45ec1f8e4db15560b3b017c9b, type: 3}
 --- !u!1 &5902274439958871315 stripped
 GameObject:
@@ -292,8 +295,7 @@ MonoBehaviour:
   distractionThreshold: 300
   damageToPlayer: 5
   speed: 0
-  _WayPointArrivedDistance: 2
-  agent: {fileID: -2116463544244376725, guid: 87b750aa9cfe0c1498a2348ee619a2ce, type: 3}
+  NavController: {fileID: -351561568029942122}
   distractReward: 50
   _DistractednessMeterHeightAboveCat: 2
   _DistractednessMeterPrefab: {fileID: 3512654570813597946, guid: e633f4d5486c0f542b4af3b4ecb326ae, type: 3}
@@ -486,3 +488,17 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &-351561568029942122
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5902274439958871315}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0760ac38ef6c51439504cf1bd752a09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _WayPointArrivedDistance: 1
+  agent: {fileID: 6060268370008954500}

--- a/Catpocalypse/Assets/Prefabs/Towers/Non Allergic Tower Prefab.prefab
+++ b/Catpocalypse/Assets/Prefabs/Towers/Non Allergic Tower Prefab.prefab
@@ -201,7 +201,7 @@ MonoBehaviour:
   _towerSound: {fileID: 518502783032453055}
   maxLevel: 4
   _towerUpgradesData: {fileID: 11400000, guid: 028949faf55f5784c828c4add00253df, type: 2}
-  numOfPeople: 2
+  maxNumOfPeople: 2
   personSpeed: 0
   spawnPoints:
   - {fileID: 737399380378500220}

--- a/Catpocalypse/Assets/Prefabs/Towers/non alergic tower model Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Towers/non alergic tower model Variant.prefab
@@ -299,7 +299,7 @@ MonoBehaviour:
   _towerSound: {fileID: 3087859885152949134}
   maxLevel: 4
   _towerUpgradesData: {fileID: 11400000, guid: 028949faf55f5784c828c4add00253df, type: 2}
-  numOfPeople: 2
+  maxNumOfPeople: 2
   personSpeed: 0
   spawnPoints:
   - {fileID: 7363447290433283373}

--- a/Catpocalypse/Assets/Prefabs/Towers/people bot Variant.prefab
+++ b/Catpocalypse/Assets/Prefabs/Towers/people bot Variant.prefab
@@ -708,7 +708,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   effectLength: 25
   petRate: 1
-  speed: 0
+  speed: 5
   _personSound: {fileID: 9172074808698999897}
 --- !u!23 &5603169663319034318
 MeshRenderer:

--- a/Catpocalypse/Assets/Scenes/MainMenu.unity
+++ b/Catpocalypse/Assets/Scenes/MainMenu.unity
@@ -1682,6 +1682,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -705044849001712320, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+      propertyPath: agent
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
       propertyPath: m_Name
       value: NormalCat
@@ -1744,6 +1748,7 @@ PrefabInstance:
     - {fileID: 4388902454001029155, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     - {fileID: 2420132660456653552, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     - {fileID: 8556101555457433808, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+    - {fileID: -705044849001712320, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -4291,6 +4296,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -705044849001712320, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+      propertyPath: agent
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
       propertyPath: m_Name
       value: NormalCat (1)
@@ -4353,6 +4362,7 @@ PrefabInstance:
     - {fileID: 4388902454001029155, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     - {fileID: 2420132660456653552, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     - {fileID: 8556101555457433808, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+    - {fileID: -705044849001712320, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -4365,6 +4375,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -705044849001712320, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+      propertyPath: agent
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 1589074876568128993, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
       propertyPath: m_Name
       value: NormalCat (2)
@@ -4427,6 +4441,7 @@ PrefabInstance:
     - {fileID: 4388902454001029155, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     - {fileID: 2420132660456653552, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     - {fileID: 8556101555457433808, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
+    - {fileID: -705044849001712320, guid: 572ce69c6cf5e804a91d52f0edc3c4c7, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Catpocalypse/Assets/Scenes/Tutorial.unity
+++ b/Catpocalypse/Assets/Scenes/Tutorial.unity
@@ -4297,68 +4297,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 186aca2b71a34214b94bc6ff6f5d98a6, type: 3}
   m_PrefabInstance: {fileID: 1308015713}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1368771933
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1532091679}
-    m_Modifications:
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.91
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -16.137167
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7654846733913619384, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-      propertyPath: m_Name
-      value: NavWayPoint (12)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
---- !u!4 &1368771934 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5595114193865858207, guid: 523990c59b87bb8469a210ecb61fd01a, type: 3}
-  m_PrefabInstance: {fileID: 1368771933}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1375903327
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4943,7 +4881,6 @@ Transform:
   - {fileID: 1299848233}
   - {fileID: 853916404}
   - {fileID: 1542720647}
-  - {fileID: 1368771934}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1542720646

--- a/Catpocalypse/Assets/Scripts/Navigation/NPCNavigationController.cs
+++ b/Catpocalypse/Assets/Scripts/Navigation/NPCNavigationController.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+public class NPCNavigationController: MonoBehaviour
+{
+    [Min(0f)]
+    [Tooltip("This sets how close the cat must get to the next WayPoint to consider itself to have arrived there. This causes it to then target the next WayPoint (or a randomly selected one if the current WayPoint has multiple next points set in the Inspector.")]
+    [SerializeField] protected float _WayPointArrivedDistance = 1f;
+
+    public NavMeshAgent agent;
+    protected float _distanceFromNextWayPoint = 0f;
+    protected WayPoint _nextWayPoint;
+    private WayPoint _goalPoint;
+    private Queue<WayPoint> currentPath;
+
+    public event EventHandler<ReachedNextWayPointEventArgs> OnTargetReachedNextWayPoint;
+
+    private void Start()
+    {
+        agent = GetComponent<NavMeshAgent>();
+        currentPath = new Queue<WayPoint>();
+        FindNearestWayPoint();
+        _goalPoint = WaveManager.Instance.WayPointUtils.FindClosestEndPoint(_nextWayPoint);
+        List<WayPoint> waypointList = WaveManager.Instance.WayPointUtils.GetPath(_nextWayPoint, _goalPoint);
+        if(waypointList == null)
+        {
+            Debug.Log("Utils don't work");
+        }
+        if (waypointList.Count <= 0)
+        {
+            Debug.Log("Utils don't work, list doesn't build correctly");
+        }
+        foreach (WayPoint p in waypointList)
+        {
+            currentPath.Enqueue(p);
+        }
+        agent.SetDestination(_nextWayPoint.transform.position);
+    }
+
+    private void Update()
+    {
+        if(agent.speed <= 0f)
+        {
+            return;
+        }
+        if (_nextWayPoint != null)
+        {
+            _distanceFromNextWayPoint = Vector3.Distance(transform.position, _nextWayPoint.transform.position);
+
+            if (HasReachedDestination())
+            {
+                OnTargetReachedNextWayPoint?.Invoke(this,
+                    new ReachedNextWayPointEventArgs
+                    {
+                        Npc = gameObject
+                    });
+                if (currentPath.Count > 0)
+                {
+                    _nextWayPoint = currentPath.Dequeue();
+                    agent.SetDestination(_nextWayPoint.transform.position);
+                }
+                else
+                {
+                    _nextWayPoint = null;
+                }
+            }
+        }
+        else
+        {
+            if(currentPath.Count > 0)
+            {
+                _nextWayPoint = currentPath.Dequeue();
+                agent.SetDestination(_nextWayPoint.transform.position);
+            } 
+            else
+            {
+                _distanceFromNextWayPoint = 0f;
+            }      
+        }
+    }
+
+    protected void FindNearestWayPoint()
+    {
+        float minDistance = float.MaxValue;
+        WayPoint nearestWayPoint = null;
+
+        foreach (WayPoint wayPoint in FindObjectsByType<WayPoint>(FindObjectsSortMode.None))
+        {
+            float distance = Vector3.Distance(transform.position, wayPoint.transform.position);
+
+            if (distance < minDistance)
+            {
+                minDistance = distance;
+                nearestWayPoint = wayPoint;
+            }
+        }
+
+
+        _nextWayPoint = nearestWayPoint;
+
+    }
+
+    public bool HasReachedDestination()
+    {
+        return _distanceFromNextWayPoint <= _WayPointArrivedDistance &&
+               agent.pathStatus <= NavMeshPathStatus.PathComplete;
+    }
+
+    public void SetTargetLocation(Vector3 location)
+    {
+        Debug.Log("")
+        WayPoint target = WaveManager.Instance.WayPointUtils.FindNearestWayPointTo(location);
+        foreach(WayPoint waypoint in WaveManager.Instance.WayPointUtils.GetPath(_nextWayPoint, target))
+        {
+            currentPath.Enqueue(waypoint);
+        }
+    }
+
+    public WayPoint NextWayPoint { get { return _nextWayPoint; } set { _nextWayPoint = value; } }
+    public float WayPointArrivedDistance { get { return _WayPointArrivedDistance; } }
+
+    public class ReachedNextWayPointEventArgs : EventArgs
+    {
+        public GameObject Npc;
+    }
+}

--- a/Catpocalypse/Assets/Scripts/Navigation/NPCNavigationController.cs.meta
+++ b/Catpocalypse/Assets/Scripts/Navigation/NPCNavigationController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0760ac38ef6c51439504cf1bd752a09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Catpocalypse/Assets/Scripts/Navigation/WayPoint.cs
+++ b/Catpocalypse/Assets/Scripts/Navigation/WayPoint.cs
@@ -1,26 +1,22 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
-
 using UnityEngine;
 
 
 public class WayPoint : MonoBehaviour
 {
     public List<WayPoint> NextWayPoints = new List<WayPoint>();
-
-
+    public List<WayPoint> PrevWayPoints = new List<WayPoint>();
 
     // Start is called before the first frame update
-    void Start()
+    void Awake()
     {
-
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-
+        if (NextWayPoints.Count > 0)
+        {
+            foreach (WayPoint wayPoint in NextWayPoints)
+            {
+                wayPoint.PrevWayPoints.Add(this);
+            }
+        }
     }
 
     private void OnDrawGizmos()
@@ -66,5 +62,25 @@ public class WayPoint : MonoBehaviour
             Gizmos.DrawLine(midPoint, leftCorner);
             Gizmos.DrawLine(rightCorner, leftCorner);
         }
+    }
+
+    public override bool Equals(object other)
+    {
+        if (other == null || other.GetType() != this.GetType())
+        {
+            Debug.LogError("Wrong Object Type");
+            return false;
+        }
+        WayPoint otherPoint = (WayPoint)other;
+        if (this.transform.Equals(otherPoint.transform))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public override int GetHashCode()
+    {
+        return transform.GetHashCode();
     }
 }

--- a/Catpocalypse/Assets/Scripts/Navigation/WayPointUtilsTester.cs
+++ b/Catpocalypse/Assets/Scripts/Navigation/WayPointUtilsTester.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-
 using UnityEngine;
 
 /// <summary>
@@ -26,7 +22,7 @@ public class WayPointUtilsTester : MonoBehaviour
     {
         if (_WayPointA != null && _WayPointB != null)
         {
-            WayPointUtils.WayPointCompareResults result = WayPointUtils.CompareWayPointPositions(_WayPointA, _WayPointB);
+            WayPointUtils.WayPointCompareResults result = WaveManager.Instance.WayPointUtils.CompareWayPointPositions(_WayPointA, _WayPointB);
             Debug.Log($"WayPointTest Result = {result}");
         }
         else

--- a/Catpocalypse/Assets/Scripts/Navigation/WaypointUtils.cs
+++ b/Catpocalypse/Assets/Scripts/Navigation/WaypointUtils.cs
@@ -1,7 +1,6 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using UnityEngine;
 
 
@@ -10,18 +9,16 @@ using UnityEngine;
 /// This class allows us to traverse the waypoint network and find out if a given waypoint comes before or after another one.
 /// The LaserTower uses this to find out where each potential target is in relation to the associated path junction.
 /// </summary>
-public static class WayPointUtils
-{
-    private static Dictionary<WayPoint, WayPointInfo> _WayPointInfoLookup; // A lookup table that gives you a list of the waypoints that reference the passed in way point.
+public class WayPointUtils
+    {
+    private Dictionary<WayPoint, WayPointInfo> _WayPointInfoLookup; // A lookup table that gives you a list of the waypoints that reference the passed in way point.
+    public Dictionary<Endpoints, WalkPathInfo> _WayPointPaths;
+    private List<WayPoint> _AllWayPointsInScene; // Holds all waypoints in the scene.
+    private List<WayPoint> _StartWayPoints; // Holds way points that are not referenced by any otherway points.
+    private List<WayPoint> _EndWayPoints; // Holds waypoints that do not have any next way points set.
+    private List<WayPoint> _OrphanedPoints; // Holds waypoints that are not referenced by any otherway points, and do not have any next waypoints set either.
 
-    private static List<WayPoint> _AllWayPointsInScene; // Holds all waypoints in the scene.
-    private static List<WayPoint> _StartWayPoints; // Holds way points that are not referenced by any otherway points.
-    private static List<WayPoint> _EndWayPoints; // Holds waypoints that do not have any next way points set.
-    private static List<WayPoint> _OrphanedPoints; // Holds waypoints that are not referenced by any otherway points, and do not have any next waypoints set either.
-
-    private static bool _IsInitialized;
-
-
+    private bool _IsInitialized;
 
     public enum WayPointCompareResults
     {
@@ -39,18 +36,23 @@ public static class WayPointUtils
         A_IsAfterB = 1,
     }
 
-
-
-    private static void Init()
+    public void Init()
     {
         _WayPointInfoLookup = new Dictionary<WayPoint, WayPointInfo>();
+        _WayPointPaths = new Dictionary<Endpoints, WalkPathInfo>();
 
         _StartWayPoints = new List<WayPoint>();
         _EndWayPoints = new List<WayPoint>();
         _OrphanedPoints = new List<WayPoint>();
 
-        _AllWayPointsInScene = GameObject.FindObjectsOfType<WayPoint>().ToList();
+        _WayPointPaths.Clear();
+        _WayPointInfoLookup.Clear();
+        _StartWayPoints.Clear();
+        _EndWayPoints.Clear();
+        _OrphanedPoints.Clear();
 
+
+        _AllWayPointsInScene = GameObject.FindObjectsOfType<WayPoint>().ToList();
 
         FindAllWayPointReferences();
 
@@ -73,31 +75,35 @@ public static class WayPointUtils
 
 
             int nextCount = p.NextWayPoints.Count;
-            refCount = wpInfo.References.Count;
+            int prevCount = p.PrevWayPoints.Count;
 
 
             // Does p link to at least one other waypoint and is not referenced by any other way point?
-            if (nextCount > 0 && refCount <= 0)
+            if (nextCount > 0 && prevCount <= 0)
+            {
                 _StartWayPoints.Add(p);
+            }
             // Does p link to 0 other waypoints and have at least one other waypoint that links into it?
-            else if (nextCount <= 0 && refCount >= 0)
+            else if (nextCount <= 0 && prevCount > 0)
+            {
                 _EndWayPoints.Add(p);
+            }
             // Does p link to 0 other waypoints and is not referenced by any other way point?
-            else if (p.NextWayPoints.Count == 0 && wpInfo.References.Count == 0)
+            else if (nextCount == 0 && prevCount == 0) { 
                 _OrphanedPoints.Add(p);
-
+            }
         } // end foreach
-
-
         //Debug.Log($"Waypoints Breakdown:  |  Total: {_AllWayPointsInScene.Count}  |  Start Points: {_StartWayPoints.Count}  |  End Points: {_EndWayPoints.Count}  |  Orphaned Points: {_OrphanedPoints.Count}");
 
+        FindAllShortestPaths();
+        //Debug.Log($"Total paths found: { _WayPointPaths.Count}");
         _IsInitialized = true;
     }
 
     /// <summary>
     /// Compiles a list for each waypoint that contains all waypoints that link into it.
     /// </summary>
-    private static void FindAllWayPointReferences()
+    private void FindAllWayPointReferences()
     {
         // Find all the waypoints that reference each way point.
         for (int i = 0; i < _AllWayPointsInScene.Count; i++)
@@ -148,78 +154,12 @@ public static class WayPointUtils
     }
 
     /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <returns> -1 if waypoint a is before waypoint b, 1 if waypoint a is after waypoint b, and 0 if a and b are the same node, and -100 if there is no path connecting the two waypoints.</returns>
-    public static WayPointCompareResults CompareWayPointPositions(WayPoint a, WayPoint b)
-    {
-        // First check if a, b, or both are null, or if they are the same waypoint.
-        // We don't need to bother with the loops below in any of these cases.
-        if (a == null && b == null)
-            return WayPointCompareResults.A_And_B_AreBothNull;
-        else if (a == null && b != null)
-            return WayPointCompareResults.A_IsNull;
-        else if (a != null && b == null)
-            return WayPointCompareResults.B_IsNull;
-        else if (a == b)
-            return WayPointCompareResults.A_And_B_AreSamePoint;
-
-
-        List<WalkPathInfo> results = new List<WalkPathInfo>();
-
-
-        if (!_IsInitialized)
-            Init();
-
-
-        // Start walking through the waypoints from each starting point.
-        foreach (WayPoint startPoint in _StartWayPoints)
-        {
-            WalkPathInfo walkPathInfo = new WalkPathInfo()
-            {
-                StartPoint = startPoint,
-                A = a,
-                B = b,
-            };
-
-
-            // Call the recursive path walking function to walk the path and record info along the way.
-            results.AddRange(WalkWaypointPath(walkPathInfo));
-
-        } // end foreach startPoint
-
-
-        // Now we need to check the results.
-        foreach (WalkPathInfo result in results)
-        {
-            //result.DEBUG_PrintWalkPathInfo();
-
-            // Did this particular path cross both waypoints A and B before it terminated?
-            if (result.VisitedA && result.VisitedB)
-            {
-                if (result.DistanceToA < result.DistanceToB)
-                    return WayPointCompareResults.A_IsBeforeB;
-                else if (result.DistanceToA > result.DistanceToB)
-                    return WayPointCompareResults.A_IsAfterB;
-            }
-        } // end foreach.
-
-
-        // None of the paths traversed visited both waypoints A and B, so return 0 to indicate that we didn't see any paths connecting them.
-        return WayPointCompareResults.NoPathConnectsA_To_B;
-    }
-
-    /// <summary>
     /// Finds the nearest WayPoint to the specified position.
     /// </summary>
     /// <param name="position">The position to find the closest WayPoint to.</param>
     /// <returns>The closest WayPoint to the specified position, or null if there are no WayPoints in the scene.</returns>
-    public static WayPoint FindNearestWayPointTo(Vector3 position)
+    public WayPoint FindNearestWayPointTo(Vector3 position)
     {
-        if (!_IsInitialized)
-            Init();
 
         if (_AllWayPointsInScene.Count <= 0)
             return null;
@@ -244,113 +184,157 @@ public static class WayPointUtils
         return nearestWayPoint;
     }
 
-    /// <summary>
-    /// This recursive function starts at the specified start point, and then walks the path
-    /// until it reaches a dead end or a junction. If it reaches a junction, it will call itself
-    /// for each path branch. It will also return if it encounters a waypoint that has already
-    /// been visited to prevent any scenario where it could get stuck going in circles forever.
-    /// </summary>
-    /// <param name="walkPathInfo">An object containing data that needs to persist between the recursive calls of this function.</param>
-    /// <returns>A list of WalkPathInfos (one for each possible path encountered).</returns>
-    private static List<WalkPathInfo> WalkWaypointPath(WalkPathInfo walkPathInfo)
+    public WayPoint FindClosestEndPoint(WayPoint currentLocation)
     {
-        List<WalkPathInfo> results = new List<WalkPathInfo>();
-
-        WayPoint currentPoint = walkPathInfo.StartPoint;
-
-        while (true)
-        {
-            walkPathInfo.DistanceTraveled++;
-
-            // If this point has already been visited, then simply return.
-            if (walkPathInfo.VisitedPoints.Contains(currentPoint))
-            {
-                results.Add(walkPathInfo);
-                break;
-            }
-
-            walkPathInfo.VisitedPoints.Add(currentPoint);
-
-
-            // Is the current waypoint A or B?
-            if (currentPoint == walkPathInfo.A)
-            {
-                walkPathInfo.VisitedA = true;
-                walkPathInfo.DistanceToA = walkPathInfo.DistanceTraveled;
-            }
-            else if (currentPoint == walkPathInfo.B)
-            {
-                walkPathInfo.VisitedB = true;
-                walkPathInfo.DistanceToB = walkPathInfo.DistanceTraveled;
-            }
-
-
-            // If the current waypoint is a deadend, or if both waypoints A and B have
-            // been visited, then break out of this loop.
-            if (currentPoint.NextWayPoints.Count <= 0 || 
-                (walkPathInfo.VisitedA && walkPathInfo.VisitedB))
-            {
-                results.Add(walkPathInfo);
-                break;
-            }
-
-
-            // If the current point is a junction point, then call this function once for each
-            // path branch, and then break out of this loop.
-            if (currentPoint.NextWayPoints.Count > 1)
-            {
-                foreach (WayPoint nextPoint in currentPoint.NextWayPoints)
+        WayPoint result = null;
+        float currentDistance = float.MaxValue;
+        foreach (WayPoint waypoint in _EndWayPoints) {
+            Endpoints endpoints = new Endpoints(currentLocation, waypoint);
+            if(_WayPointPaths.TryGetValue(endpoints, out WalkPathInfo path)){
+                if(currentDistance > path.DistanceTraveled)
                 {
-                    WalkPathInfo clone = walkPathInfo.Clone();
-                    clone.StartPoint = nextPoint;
-
-                    results.AddRange(WalkWaypointPath(clone));
-                } // end foreach
-
-                break;
+                    result = waypoint;
+                    currentDistance = path.DistanceTraveled;
+                }
+            } else
+            {
+                Debug.LogError("No path between " + endpoints.Start.ToString() + " and " + endpoints.End.ToString());
             }
+        }
+        if (result == null)
+        {
+            Debug.LogError("No WayPoint found");
+        }
+        return result;
+    }
+    private void FindAllShortestPaths()
+    {
+        Queue<WalkPathInfo> queue = new Queue<WalkPathInfo>();
+        foreach (WayPoint wayPoint in _AllWayPointsInScene)
+        {
+            WalkPathInfo wayPathInfo = new WalkPathInfo();
+            wayPathInfo.StartPoint = wayPoint;
+            wayPathInfo.VisitedPoints.Add(wayPoint);
+            queue.Enqueue(wayPathInfo);
+        }
+        while(queue.Count > 0)
+        {
+            WalkPathInfo walkPath = queue.Dequeue();
+            WayPoint currentWayPoint = walkPath.VisitedPoints[walkPath.VisitedPoints.Count - 1];
 
-
-            // If this waypoint has multiple next waypoints, that was already handled above.
-            // The same is true if it has none. So here we just need to move our pointer to
-            // the next waypoint in line.
-            currentPoint = currentPoint.NextWayPoints[0];
-
-        } // end while
-
-
-        // Debug.Log($"Results Count: {results.Count}");
+            //Walk Both Forwards and Backwards
+            foreach(WayPoint wayPoint in currentWayPoint.NextWayPoints)
+            {
+                if (!walkPath.VisitedPoints.Contains(wayPoint))
+                {
+                    WalkPathInfo clonedPath = walkPath.Clone();
+                    clonedPath.VisitedPoints.Add(wayPoint);
+                    clonedPath.DistanceTraveled += Vector3.Distance(currentWayPoint.transform.position, wayPoint.transform.position);
+                    Endpoints endpoints = new Endpoints(walkPath.StartPoint, wayPoint);
+                    if(_WayPointPaths.TryGetValue(endpoints, out WalkPathInfo existingPath))
+                    {
+                        if(existingPath.DistanceTraveled > clonedPath.DistanceTraveled)
+                        {
+                            _WayPointPaths[endpoints] =clonedPath;
+                        }
+                    }
+                    else
+                    {
+                        _WayPointPaths.Add(endpoints, clonedPath);
+                    }
+                    if (!_EndWayPoints.Contains(wayPoint))
+                    {
+                        queue.Enqueue(clonedPath);
+                    }
+                }
+            }
+            foreach(WayPoint wayPoint in currentWayPoint.PrevWayPoints)
+            {
+                if (!walkPath.VisitedPoints.Contains(wayPoint))
+                {
+                    WalkPathInfo clonedPath = walkPath.Clone();
+                    clonedPath.VisitedPoints.Add(wayPoint);
+                    clonedPath.DistanceTraveled += Vector3.Distance(currentWayPoint.transform.position, wayPoint.transform.position);
+                    Endpoints endpoints = new Endpoints(walkPath.StartPoint, wayPoint);
+                    if (_WayPointPaths.TryGetValue(endpoints, out WalkPathInfo existingPath))
+                    {
+                        if (existingPath.DistanceTraveled > clonedPath.DistanceTraveled)
+                        {
+                            _WayPointPaths.Add(endpoints, clonedPath);
+                        }
+                    }
+                    else
+                    {
+                        _WayPointPaths.Add(endpoints, clonedPath);
+                    }
+                    if (!_StartWayPoints.Contains(wayPoint))
+                    {
+                        queue.Enqueue(clonedPath);
+                    }
+                }
+            }
             
-        return results;
+        }
     }
 
-
-    public static int GetWayPointReferenceCount(WayPoint p)
+    public int GetWayPointReferenceCount(WayPoint p)
     {
         return _WayPointInfoLookup[p].References.Count;
     }
 
-    public static bool IsJunctionWayPoint(WayPoint p)
+    /// <summary>
+    /// This function checks the dictionary of paths to see if a path exists between Waypoint a
+    /// and Waypoint b. If that path does not exist, but a path from Waypoint b to Waypoint a exists, 
+    /// it returns the inverted path from Waypoint b to Waypoint a. If no path at all, it throws an error.
+    /// </summary>
+    /// <param name="a">The start Waypoint a to Waypoint b</returns>
+    public List<WayPoint> GetPath(WayPoint a, WayPoint b)
+    {
+        if(a == null)
+        {
+            Debug.LogError("Start WayPoint does not exist");
+        }
+        if(b== null)
+        {
+            Debug.LogError("End WayPoint does not exist");
+        }
+        Endpoints endpoints = new Endpoints(a, b);
+        WalkPathInfo pathing = _WayPointPaths[endpoints];
+        if (_WayPointPaths.TryGetValue(endpoints, out WalkPathInfo path)){
+            return path.VisitedPoints;
+        }
+        endpoints = new Endpoints(b, a);
+        if (_WayPointPaths.TryGetValue(endpoints, out path))
+        {
+            List<WayPoint> wayPointList = path.VisitedPoints;
+            wayPointList.Reverse();
+            return wayPointList;
+        }
+        Debug.LogError($"No path found between {a.ToString()} and {b.ToString()}");
+        return null;
+    }
+
+    public bool IsJunctionWayPoint(WayPoint p)
     {
         return p.NextWayPoints.Count > 1;
     }
 
-    public static bool IsStartingWayPoint(WayPoint p)
+    public bool IsStartingWayPoint(WayPoint p)
     {
         return _StartWayPoints.Contains(p);
     }
 
-    public static bool IsEndingWayPoint(WayPoint p)
+    public bool IsEndingWayPoint(WayPoint p)
     {
         return _EndWayPoints.Contains(p);
     }
 
-    public static bool IsOrphanedWayPoint(WayPoint p)
+    public bool IsOrphanedWayPoint(WayPoint p)
     {
         return _OrphanedPoints.Contains(p);
     }
 
-    class WalkPathInfo
+    public class WalkPathInfo : IEquatable<WalkPathInfo>
     {
         public WayPoint StartPoint; // Specifies which waypoint the WalkWayPointPath() function will start at.
 
@@ -407,12 +391,203 @@ public static class WayPointUtils
 
             Debug.Log(separator);
         }
+
+        public bool Equals(WalkPathInfo other)
+        {
+            if (other == null)
+            {
+                Debug.Log("WalkPathInfo is null");
+                return false;
+            }
+            if (!this.StartPoint.Equals(other.StartPoint)) return false;
+            if(!this.DistanceTraveled.Equals(other.DistanceTraveled)) return false;
+            if(!this.VisitedPoints.Equals(other.VisitedPoints)) return false;
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 
-    class WayPointInfo
+    public class WayPointInfo
     {
         // Holds a list of all WayPoints that reference this one.
         public List<WayPoint> References = new List<WayPoint>();
     }
 
+    public class Endpoints
+    {
+        public Endpoints(WayPoint start, WayPoint end)
+        {
+            Start = start;
+            End = end;
+        }
+        public WayPoint Start;
+        public WayPoint End;
+
+        public override bool Equals(object other)
+        {
+            if (other == null || other.GetType() != this.GetType())
+            {
+                Debug.LogError("Wrong Object Type");
+                return false;
+            }
+            Endpoints compareEndpoints = (Endpoints) other;
+            if(this.Start.Equals(compareEndpoints.Start) && this.End.Equals(compareEndpoints.End)) return true;
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Start, End);
+        }
+    }
+
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="a"></param>
+    /// <param name="b"></param>
+    /// <returns> -1 if waypoint a is before waypoint b, 1 if waypoint a is after waypoint b, and 0 if a and b are the same node, and -100 if there is no path connecting the two waypoints.</returns>
+    public WayPointCompareResults CompareWayPointPositions(WayPoint a, WayPoint b)
+    {
+        // First check if a, b, or both are null, or if they are the same waypoint.
+        // We don't need to bother with the loops below in any of these cases.
+        if (a == null && b == null)
+            return WayPointCompareResults.A_And_B_AreBothNull;
+        else if (a == null && b != null)
+            return WayPointCompareResults.A_IsNull;
+        else if (a != null && b == null)
+            return WayPointCompareResults.B_IsNull;
+        else if (a == b)
+            return WayPointCompareResults.A_And_B_AreSamePoint;
+        return WayPointCompareResults.NoPathConnectsA_To_B;
+        /**
+        List<WalkPathInfo> results = new List<WalkPathInfo>();
+
+
+        if (!_IsInitialized)
+            //Init();
+
+
+        // Start walking through the waypoints from each starting point.
+        foreach (WayPoint startPoint in _StartWayPoints)
+        {
+            WalkPathInfo walkPathInfo = new WalkPathInfo()
+            {
+                StartPoint = startPoint,
+                A = a,
+                B = b,
+            };
+
+
+            // Call the recursive path walking function to walk the path and record info along the way.
+            results.AddRange(WalkWaypointPath(walkPathInfo));
+
+        } // end foreach startPoint
+
+
+        // Now we need to check the results.
+        foreach (WalkPathInfo result in results)
+        {
+            //result.DEBUG_PrintWalkPathInfo();
+
+            // Did this particular path cross both waypoints A and B before it terminated?
+            if (result.VisitedA && result.VisitedB)
+            {
+                if (result.DistanceToA < result.DistanceToB)
+                    return WayPointCompareResults.A_IsBeforeB;
+                else if (result.DistanceToA > result.DistanceToB)
+                    return WayPointCompareResults.A_IsAfterB;
+            }
+        } // end foreach.
+
+
+        // None of the paths traversed visited both waypoints A and B, so return 0 to indicate that we didn't see any paths connecting them.
+        return WayPointCompareResults.NoPathConnectsA_To_B;
+    */
+    }
+    /**
+    /// <summary>
+    /// This recursive function starts at the specified start point, and then walks the path
+    /// until it reaches a dead end or a junction. If it reaches a junction, it will call itself
+    /// for each path branch. It will also return if it encounters a waypoint that has already
+    /// been visited to prevent any scenario where it could get stuck going in circles forever.
+    /// </summary>
+    /// <param name="walkPathInfo">An object containing data that needs to persist between the recursive calls of this function.</param>
+    /// <returns>A list of WalkPathInfos (one for each possible path encountered).</returns>
+    private List<WalkPathInfo> WalkWaypointPath(WalkPathInfo walkPathInfo)
+    {
+        List<WalkPathInfo> results = new List<WalkPathInfo>();
+
+        WayPoint currentPoint = walkPathInfo.StartPoint;
+
+        while (true)
+        {
+            walkPathInfo.DistanceTraveled++;
+
+            // If this point has already been visited, then simply return.
+            if (walkPathInfo.VisitedPoints.Contains(currentPoint))
+            {
+                results.Add(walkPathInfo);
+                break;
+            }
+
+            walkPathInfo.VisitedPoints.Add(currentPoint);
+
+            // Is the current waypoint A or B?
+            if (currentPoint == walkPathInfo.A)
+            {
+                walkPathInfo.VisitedA = true;
+                walkPathInfo.DistanceToA = walkPathInfo.DistanceTraveled;
+            }
+            else if (currentPoint == walkPathInfo.B)
+            {
+                walkPathInfo.VisitedB = true;
+                walkPathInfo.DistanceToB = walkPathInfo.DistanceTraveled;
+            }
+
+
+            // If the current waypoint is a deadend, or if both waypoints A and B have
+            // been visited, then break out of this loop.
+            if (currentPoint.NextWayPoints.Count <= 0 ||
+                (walkPathInfo.VisitedA && walkPathInfo.VisitedB))
+            {
+                results.Add(walkPathInfo);
+                break;
+            }
+
+
+            // If the current point is a junction point, then call this function once for each
+            // path branch, and then break out of this loop.
+            if (currentPoint.NextWayPoints.Count > 1)
+            {
+                foreach (WayPoint nextPoint in currentPoint.NextWayPoints)
+                {
+                    WalkPathInfo clone = walkPathInfo.Clone();
+                    clone.StartPoint = nextPoint;
+
+                    results.AddRange(WalkWaypointPath(clone));
+                } // end foreach
+
+                break;
+            }
+
+
+            // If this waypoint has multiple next waypoints, that was already handled above.
+            // The same is true if it has none. So here we just need to move our pointer to
+            // the next waypoint in line.
+            currentPoint = currentPoint.NextWayPoints[0];
+
+        } // end while
+
+
+        // Debug.Log($"Results Count: {results.Count}");
+
+        return results;
+    }
+    */
 }

--- a/Catpocalypse/Assets/Scripts/Towers/NonAllergicPerson.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/NonAllergicPerson.cs
@@ -25,6 +25,9 @@ public class NonAllergicPerson : MonoBehaviour
     [SerializeField]
     private AudioSource _personSound;
 
+    [Tooltip("Controls the NPC's navigation")]
+    public NPCNavigationController NavController;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -38,6 +41,7 @@ public class NonAllergicPerson : MonoBehaviour
         {
             agent.speed *= PlayerDataManager.Instance.Upgrades.NAMoveSpeedUpgrade;
         }
+        
     }
    
     // Update is called once per frame
@@ -52,21 +56,7 @@ public class NonAllergicPerson : MonoBehaviour
             }
             if (target != null && tower.targets.Contains(target.gameObject))
             {
-                if (!isPetting)
-                {
-                    if (CatDistance(target.gameObject) <= 2)
-                    {
-                        target.stoppingEntities.Add(gameObject);
-                        _personSound.Play();
-                        StartCoroutine(PetCat(effectLength));
-
-                    }
-                    else
-                    {
-                        agent.SetDestination(target.transform.position);
-                    }
-
-                }
+                CatTargetingHelper();
             }
             //If the person has a target that is not in the list, the person does not have a target
             if (target != null && !tower.targets.Contains(target.gameObject))
@@ -84,21 +74,7 @@ public class NonAllergicPerson : MonoBehaviour
             }
             if (target != null && fort.targets.Contains(target.gameObject))
             {
-                if (!isPetting)
-                {
-                    if (CatDistance(target.gameObject) <= 2)
-                    {
-                        target.stoppingEntities.Add(gameObject);
-                        _personSound.Play();
-                        StartCoroutine(PetCat(effectLength));
-
-                    }
-                    else
-                    {
-                        agent.SetDestination(target.transform.position);
-                    }
-
-                }
+                CatTargetingHelper();
             }
             //If the person has a target that is not in the list, the person does not have a target
             if (target != null && !fort.targets.Contains(target.gameObject))
@@ -133,7 +109,7 @@ public class NonAllergicPerson : MonoBehaviour
 
             }
         }
-        if (fort != null)
+        else if (fort != null)
         {
             foreach (GameObject cat in fort.targets)
             {
@@ -158,6 +134,7 @@ public class NonAllergicPerson : MonoBehaviour
         {
             target.isATarget = true;
             agent.SetDestination(target.transform.position);
+            Debug.Log("Chasing a cat");
         }
     }
     //Finds the distance between the person and the cat
@@ -168,6 +145,31 @@ public class NonAllergicPerson : MonoBehaviour
         float yDist =  Mathf.Pow(transform.position.x - cat.transform.position.x, 2);
         distance = Mathf.Sqrt(xDist + yDist);
         return distance;
+    }
+
+    private void CatTargetingHelper()
+    {
+        if (!isPetting)
+        {
+            float distance = CatDistance(target.gameObject);
+            if ( distance <= 2)
+            {
+                target.stoppingEntities.Add(gameObject);
+                _personSound.Play();
+                StartCoroutine(PetCat(effectLength));
+
+            }
+            else
+            {
+                SetMovementTarget();
+            }
+
+        }
+    }
+
+    private void SetMovementTarget()
+    {
+        agent.SetDestination(target.transform.position);
     }
     
     private void OnTriggerExit(Collider other)
@@ -225,7 +227,6 @@ public class NonAllergicPerson : MonoBehaviour
         {
             fort.targets.Remove(target.gameObject);
         }
-        Debug.Log("Removing target " + target);
         StopAllCoroutines();
         if (target != null)
         {

--- a/Catpocalypse/Assets/Scripts/Towers/NonAllergicTower.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/NonAllergicTower.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class NonAllergicTower : Tower
 {
     [SerializeField, Tooltip("The number of people the tower spawns"),Min(1)]
-    private int numOfPeople;
+    private int maxNumOfPeople;
     private int peopleSpawned;
     [SerializeField, Tooltip("The speed of the spawned people")] private float personSpeed;
     [SerializeField, Tooltip("List of potential locations for the people to spawn")]
@@ -13,7 +13,7 @@ public class NonAllergicTower : Tower
     [SerializeField, Tooltip("The Non-Allergic people that the tower spawns")]
     private GameObject person;
     private GameObject[] waypoints;
-    private GameObject closestWaypoint;
+    private WayPoint closestWaypoint;
     private Transform spawnPoint;
     private List<GameObject> personList;
     public bool Enabled = true;
@@ -39,12 +39,14 @@ public class NonAllergicTower : Tower
         {
             Enabled = false;
         }
-        waypoints = GameObject.FindGameObjectsWithTag("Waypoint");
-        StartCoroutine(Spawner());
         peopleSpawned = 0;
-        closestWaypoint = GetClosestWaypoint();
+        if (FindNearestWayPoint(out WayPoint closestPoint))
+        {
+            closestWaypoint = closestPoint;
+        }
         personList = new List<GameObject>();
         float dist = 100000;
+
         foreach(Transform spawn in spawnPoints)
         {
 
@@ -54,8 +56,11 @@ public class NonAllergicTower : Tower
                 dist = Vector3.Distance(spawn.position, closestWaypoint.transform.position);
             }
         }
-        
+        Debug.Log("I should be spawning");
+        StartCoroutine(Spawner());
     }
+
+    
 
 
     protected override void ApplyScrapUpgrades()
@@ -81,26 +86,10 @@ public class NonAllergicTower : Tower
         }
     }
 
-    //Gets closest navigation waypoint to the tower
-    private GameObject GetClosestWaypoint()
-    {
-        GameObject waypoint = null;
-        float distance = 10000000;
-        foreach(GameObject point in waypoints)
-        {
-            if(Vector3.Distance(transform.position,point.transform.position) < distance)
-            {
-                distance = Vector3.Distance(transform.position, point.transform.position);
-                waypoint = point;
-            }
-        }
-        return waypoint;
-    }
-
     public override void Upgrade()
     {
         base.Upgrade();
-        numOfPeople++;
+        maxNumOfPeople++;
         if (towerLevel == 1)
         {
             foodTimeUnlocked = true;
@@ -155,17 +144,16 @@ public class NonAllergicTower : Tower
         yield return new WaitForSeconds(towerStats.FireRate);
         if (Enabled)
         {
-            if (peopleSpawned >= numOfPeople)
+            if (peopleSpawned >= maxNumOfPeople)
             {
 
                 StopCoroutine(Spawner());
             }
-            if (peopleSpawned < numOfPeople)
+            else
             {
 
                 GameObject newPerson = Instantiate(person, _RallyPoint, Quaternion.identity, gameObject.transform);
                 _towerSound.Play();
-                Debug.LogWarning("Person spawned");
                 //personList.Add(newPerson);
 
                 peopleSpawned++;
@@ -179,5 +167,5 @@ public class NonAllergicTower : Tower
         
     }
 
-    public int ActiveUnits {  get { return numOfPeople; } }
+    public int ActiveUnits {  get { return peopleSpawned; } }
 }

--- a/Catpocalypse/Assets/Scripts/Towers/Tower.cs
+++ b/Catpocalypse/Assets/Scripts/Towers/Tower.cs
@@ -1,11 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-
 using UnityEngine;
-using UnityEngine.InputSystem.XR.Haptics;
-using static UnityEngine.Rendering.DebugUI;
 
 
 [RequireComponent(typeof(StateMachine))]
@@ -71,19 +66,6 @@ public class Tower : MonoBehaviour
 
     [SerializeField]
     public TowerUpgradesData _towerUpgradesData;
-    public float FireRate
-    {
-        set 
-        { 
-            fireRate = value;
-        }
-        get 
-        { 
-            return fireRate; 
-        }
-    }
-
-
 
     protected void Awake()
     {
@@ -280,16 +262,6 @@ public class Tower : MonoBehaviour
         gameObject.GetComponent<Renderer>().material = gameObject.GetComponentInParent<TowerBase>().towerNotHovered;
     }
 
-    void OnMouseUpAsButton()
-    {
-
-        if (enabled)
-        {
-            
-
-        }
-    }
-
     private void OnCatDied(object sender, EventArgs e)
     {
         OnTargetHasDied((GameObject) sender);
@@ -334,7 +306,7 @@ public class Tower : MonoBehaviour
     /// </summary>
     /// <param name="wayPoint">This out parameter returns the nearest WayPoint within the tower's range, or null if none was found.</param>
     /// <returns>True if the nearest WayPoint was found, or false if none were in range.</returns>
-    private bool FindNearestWayPoint(out WayPoint wayPoint)
+    protected bool FindNearestWayPoint(out WayPoint wayPoint)
     {
         _WayPointsInRange.Clear();
         wayPoint = null;
@@ -437,7 +409,7 @@ public class Tower : MonoBehaviour
         {
             _RallyPoint = newRallyPoint;
 
-            _ClosestWayPointToRP = WayPointUtils.FindNearestWayPointTo(_RallyPoint);
+            _ClosestWayPointToRP = WaveManager.Instance.WayPointUtils.FindNearestWayPointTo(_RallyPoint);
 
             OnRallyPointChanged();
         }
@@ -456,6 +428,7 @@ public class Tower : MonoBehaviour
 
     public float BuildCost { get { return buildCost; } }
     public float DistractValue { set { distractValue = value; } get { return distractValue; } }
+    public float FireRate { set { fireRate = value; } get { return fireRate; } }
     public bool IsTargetDetectionEnabled { get { return range.enabled; } }
 
     public TowerBase ParentTowerBase { get; set; }

--- a/Catpocalypse/Assets/Scripts/WaveManager.cs
+++ b/Catpocalypse/Assets/Scripts/WaveManager.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.UI;
 
 
 /// <summary>
@@ -44,6 +42,8 @@ public class WaveManager : MonoBehaviour
     [SerializeField] AudioClip _endClip;
     [SerializeField] private int _ScrapReward;
 
+    private WayPointUtils _WayPointUtils;
+
 
     private void Awake()
     {
@@ -53,15 +53,14 @@ public class WaveManager : MonoBehaviour
             Destroy(gameObject);
             return;
         }
-
         Instance = this;
+        _WayPointUtils = new WayPointUtils();
     }
 
     private void Start()
     {
         _PlayerMoneyManager = FindObjectOfType<PlayerMoneyManager>();
         _cutenessManager = GameObject.FindGameObjectWithTag("Goal").GetComponent<PlayerCutenessManager>();
-
         CatBase.OnCatDied += OnCatDied;
         CatBase.OnCatReachGoal += OnCatReachGoal;
         _CatSpawners = new List<CatSpawner>();
@@ -77,6 +76,7 @@ public class WaveManager : MonoBehaviour
             }
         }
         HUD.HideWaveDisplay();
+        _WayPointUtils.Init();
     }
 
     private void Update()
@@ -247,5 +247,6 @@ public class WaveManager : MonoBehaviour
     public float SecondsElapsedSinceLevelStarted { get { return _SecondsSinceLevelStart; } }
     public float SecondsElapsedSinceWaveStarted { get { return _SecondsSinceWaveStart; } }
 
+    public WayPointUtils WayPointUtils { get { return _WayPointUtils; } }
 }
 


### PR DESCRIPTION
### Navigation Changes:
- NPC navigation logic is now contained within the NPCNavigationController class.
- This change affects both cats and friendly NPCs
- WayPointUtils is no longer static so that the game only needs to run graph iteration at the start of the level instead of every time a NPC changes what path it needs to take
- WayPoint Utils uses a modified Djikstra algorithm to find and store all shortest paths in the WayPoint graph.
- GetPath returns the shortest path to any given point at constant time
- Endpoints are used for accessing paths between two points from the WayPoint Utils class
- Added GetHashCode and Equals functions to all classes that need to be compared

### TODO:
- Correct LaserPointerTower to direct cats to different junction paths.
- Properly lock NonAllergicPersons to the edge of the NonAllergicTower range.